### PR TITLE
Refactor and cleanup utils

### DIFF
--- a/rmf_building_sim_common/CMakeLists.txt
+++ b/rmf_building_sim_common/CMakeLists.txt
@@ -33,6 +33,18 @@ find_package(menge QUIET)
 include(GNUInstallDirs)
 
 ###############################
+# Utils                       #
+###############################
+
+add_library(rmf_building_sim_utils SHARED ${PROJECT_SOURCE_DIR}/src/utils.cpp)
+
+target_include_directories(rmf_building_sim_utils
+  PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
+)
+
+###############################
 # door stuff
 ###############################
 
@@ -50,6 +62,10 @@ target_include_directories(door_common
    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
 )
 
+target_link_libraries(door_common
+    rmf_building_sim_utils
+)
+
 ###############################
 # lift stuff
 ###############################
@@ -63,11 +79,14 @@ ament_target_dependencies(lift_common
    rmf_lift_msgs
 )
 
-
 target_include_directories(lift_common
  PUBLIC
    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
+)
+
+target_link_libraries(lift_common
+    rmf_building_sim_utils
 )
 
 ###############################
@@ -108,8 +127,16 @@ endif()
 ###############################
 
 ament_export_include_directories(include)
+ament_export_targets(rmf_building_sim_utils HAS_LIBRARY_TARGET)
 ament_export_targets(door_common HAS_LIBRARY_TARGET)
 ament_export_targets(lift_common HAS_LIBRARY_TARGET)
+
+install(
+  TARGETS rmf_building_sim_utils
+  EXPORT rmf_building_sim_utils
+  LIBRARY DESTINATION lib
+  ARCHIVE DESTINATION lib
+)
 
 install(
   TARGETS door_common 

--- a/rmf_building_sim_common/include/rmf_building_sim_common/utils.hpp
+++ b/rmf_building_sim_common/include/rmf_building_sim_common/utils.hpp
@@ -6,16 +6,6 @@
 
 namespace rmf_building_sim_common {
 
-// TODO(MXG): Refactor the use of this function to replace it with
-// compute_desired_rate_of_change()
-double compute_ds(
-  double s_target,
-  double v_actual,
-  double v_max,
-  double accel_nom,
-  double accel_max,
-  double dt);
-
 struct MotionParams
 {
   double v_max = 0.2;
@@ -26,98 +16,22 @@ struct MotionParams
 };
 
 //==============================================================================
+// TODO(MXG): Refactor the use of this function to replace it with
+// compute_desired_rate_of_change()
 double compute_ds(
   double s_target,
   double v_actual,
   const double v_max,
   const double accel_nom,
   const double accel_max,
-  const double dt)
-{
-  double sign = 1.0;
-  if (s_target < 0.0)
-  {
-    // Limits get confusing when we need to go backwards, so we'll flip signs
-    // here so that we pretend the target is forwards
-    s_target *= -1.0;
-    v_actual *= -1.0;
-    sign = -1.0;
-  }
-
-  // We should try not to shoot past the targstd::vector<event::ConnectionPtr> connections;et
-  double next_s = s_target / dt;
-
-  // Test velocity limit
-  next_s = std::min(next_s, v_max);
-
-  // Test acceleration limit
-  next_s = std::min(next_s, accel_nom * dt + v_actual);
-
-  if (v_actual > 0.0 && s_target > 0.0)
-  {
-    // This is what our deceleration should be if we want to begin a constant
-    // deceleration from now until we reach the goal
-    double deceleration = pow(v_actual, 2) / s_target;
-    deceleration = std::min(deceleration, accel_max);
-
-    if (accel_nom <= deceleration)
-    {
-      // If the smallest constant deceleration for reaching the goal is
-      // greater than
-      next_s = -deceleration * dt + v_actual;
-    }
-  }
-
-  // Flip the sign the to correct direction before returning the value
-  return sign * next_s;
-}
+  const double dt);
 
 //==============================================================================
 double compute_desired_rate_of_change(
-  double _s_target,
-  double _v_actual,
-  const MotionParams& _motion_params,
-  const double _dt)
-{
-  double sign = 1.0;
-  if (_s_target < 0.0)
-  {
-    // Limits get confusing when we need to go backwards, so we'll flip signs
-    // here so that we pretend the target is forwards
-    _s_target *= -1.0;
-    _v_actual *= -1.0;
-    sign = -1.0;
-  }
-
-  // We should try not to shoot past the target
-  double v_next = _s_target / _dt;
-
-  // Test velocity limit
-  v_next = std::min(v_next, _motion_params.v_max);
-
-  // Test acceleration limit
-  v_next = std::min(v_next, _motion_params.a_nom * _dt + _v_actual);
-
-  if (_v_actual > 0.0 && _s_target > 0.0)
-  {
-    // This is what our deceleration should be if we want to begin a constant
-    // deceleration from now until we reach the goal
-    double deceleration = pow(_v_actual, 2) / (2.0 * _s_target);
-    deceleration = std::min(deceleration, _motion_params.a_max);
-
-    if (_motion_params.a_nom <= deceleration)
-    {
-      // If the smallest constant deceleration for reaching the goal is
-      // greater than the nominal acceleration, then we should begin
-      // decelerating right away so that we can smoothly reach the goal while
-      // decelerating as close to the nominal acceleration as possible.
-      v_next = -deceleration * _dt + _v_actual;
-    }
-  }
-
-  // Flip the sign the to correct direction before returning the value
-  return sign * v_next;
-}
+    double _s_target,
+    double _v_actual,
+    const MotionParams& _motion_params,
+    const double _dt);
 
 //==============================================================================
 template<typename SdfPtrT, typename SdfElementPtrT>
@@ -136,20 +50,7 @@ bool get_element_required(
   return true;
 }
 
-/*
-double compute_desired_rate_of_change(
-    double _s_target,
-    double _v_actual,
-    const MotionParams& _motion_params,
-    const double _dt);
-
-bool get_element_required(
-    const sdf::ElementPtr& _sdf,
-    const std::string& _element_name,
-    sdf::ElementPtr& _element);
-*/
-
-////////////////////////////////////////////////////////////////////////////////////////////////////
+//==============================================================================
 template<typename T, typename SdfPtrT>
 bool get_sdf_attribute_required(SdfPtrT& sdf, const std::string& attribute_name,
   T& value)
@@ -177,7 +78,7 @@ bool get_sdf_attribute_required(SdfPtrT& sdf, const std::string& attribute_name,
   return false;
 }
 
-////////////////////////////////////////////////////////////////////////////////////////////////////
+//==============================================================================
 template<typename T, typename SdfPtrT>
 bool get_sdf_param_required(SdfPtrT& sdf, const std::string& parameter_name,
   T& value)
@@ -204,7 +105,7 @@ bool get_sdf_param_required(SdfPtrT& sdf, const std::string& parameter_name,
   return false;
 }
 
-////////////////////////////////////////////////////////////////////////////////////////////////////
+//==============================================================================
 template<typename T, typename SdfPtrT>
 void get_sdf_param_if_available(SdfPtrT& sdf, const std::string& parameter_name,
   T& value)

--- a/rmf_building_sim_common/src/utils.cpp
+++ b/rmf_building_sim_common/src/utils.cpp
@@ -3,7 +3,7 @@
 
 #include <rmf_building_sim_common/utils.hpp>
 
-namespace rmf_building_sim_gazebo_plugins {
+namespace rmf_building_sim_common {
 
 //==============================================================================
 double compute_ds(
@@ -98,20 +98,4 @@ double compute_desired_rate_of_change(
   // Flip the sign to the correct direction before returning the value
   return sign * v_next;
 }
-
-//==============================================================================
-bool get_element_required(
-  const sdf::ElementPtr& _sdf,
-  const std::string& _element_name,
-  sdf::ElementPtr& _element)
-{
-  if (!_sdf->HasElement(_element_name))
-  {
-    std::cerr << "Element [" << _element_name << "] not found" << std::endl;
-    return false;
-  }
-  _element = _sdf->GetElement(_element_name);
-  return true;
-}
-
-} // namespace rmf_building_sim_gazebo_plugins
+} // namespace rmf_building_sim_common

--- a/rmf_robot_sim_common/CMakeLists.txt
+++ b/rmf_robot_sim_common/CMakeLists.txt
@@ -33,14 +33,14 @@ include(GNUInstallDirs)
 # Utils                       #
 ###############################
 
-add_library(rmf_sim_utils SHARED ${PROJECT_SOURCE_DIR}/src/utils.cpp)
+add_library(rmf_robot_sim_utils SHARED ${PROJECT_SOURCE_DIR}/src/utils.cpp)
 
-ament_target_dependencies(rmf_sim_utils
+ament_target_dependencies(rmf_robot_sim_utils
   rclcpp
   Eigen3
 )
 
-target_include_directories(rmf_sim_utils
+target_include_directories(rmf_robot_sim_utils
   PUBLIC
     ${EIGEN3_INCLUDE_DIRS}
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
@@ -136,6 +136,10 @@ target_include_directories(slotcar_common
     ${GAZEBO_INCLUDE_DIRS}
 )
 
+target_link_libraries(slotcar_common
+    rmf_robot_sim_utils
+)
+
 ###############################
 # Install Targets             #
 ###############################
@@ -144,7 +148,7 @@ ament_export_include_directories(include)
 ament_export_targets(ingestor_common HAS_LIBRARY_TARGET)
 ament_export_targets(dispenser_common HAS_LIBRARY_TARGET)
 ament_export_targets(readonly_common HAS_LIBRARY_TARGET)
-ament_export_targets(rmf_sim_utils HAS_LIBRARY_TARGET)
+ament_export_targets(rmf_robot_sim_utils HAS_LIBRARY_TARGET)
 ament_export_targets(slotcar_common HAS_LIBRARY_TARGET)
 
 install(
@@ -169,8 +173,8 @@ install(
 )
 
 install(
-  TARGETS rmf_sim_utils
-  EXPORT rmf_sim_utils
+  TARGETS rmf_robot_sim_utils
+  EXPORT rmf_robot_sim_utils
   LIBRARY DESTINATION lib
   ARCHIVE DESTINATION lib
 )

--- a/rmf_robot_sim_common/include/rmf_robot_sim_common/utils.hpp
+++ b/rmf_robot_sim_common/include/rmf_robot_sim_common/utils.hpp
@@ -57,10 +57,10 @@ struct SimEntity
 double compute_ds(
   double s_target,
   double v_actual,
-  double v_max,
-  double accel_nom,
-  double accel_max,
-  double dt);
+  const double v_max,
+  const double accel_nom,
+  const double accel_max,
+  const double dt);
 
 struct MotionParams
 {


### PR DESCRIPTION
## Bug fix

### Fixed bug

Utility libraries were not being properly linked and one of them (the one in `rmf_building_sim_common`) only happened to work because the code was duplicated between header and .cpp file.


### Fix applied

This PR removes all the code duplication in the `utils.hpp` file and links correctly the libraries through `target_link_libraries`.
The `utils.cpp` file was actually in the `rmf_building_sim_gazebo_plugins` namespace so it wasn't used anywhere.

### TODO
Figure out if we should move the utils code to a common library, a lot of functions are now duplicated between `rmf_robot_sim_common` and `rmf_building_sim_common`