### PR TITLE
Crowd step size fix for large physics step sizes

### DIFF
--- a/rmf_building_sim_common/include/rmf_building_sim_common/crowd_simulator_common.hpp
+++ b/rmf_building_sim_common/include/rmf_building_sim_common/crowd_simulator_common.hpp
@@ -188,7 +188,7 @@ public:
   double get_sim_time_step() const;
   size_t get_num_objects() const;
   ObjectPtr get_object_by_id(size_t id) const;
-  void one_step_sim() const;
+  void one_step_sim(double time_step) const;
   double get_switch_anim_distance_th() const;
   std::vector<std::string> get_switch_anim_name() const;
   bool enabled() const;

--- a/rmf_building_sim_common/src/crowd_simulator_common.cpp
+++ b/rmf_building_sim_common/src/crowd_simulator_common.cpp
@@ -44,6 +44,11 @@ std::shared_ptr<MengeHandle> MengeHandle::init_and_make(
 void MengeHandle::set_sim_time_step(float sim_time_step)
 {
   this->_sim_time_step = sim_time_step;
+  // Set it if a valid handle is present
+  if (this->_sim)
+  {
+    this->_sim->setTimeStep(sim_time_step);
+  }
 }
 
 float MengeHandle::get_sim_time_step() const
@@ -241,8 +246,9 @@ const
   return _objects[id];
 }
 
-void CrowdSimInterface::one_step_sim() const
+void CrowdSimInterface::one_step_sim(double time_step) const
 {
+  _menge_handle->set_sim_time_step(time_step);
   _menge_handle->sim_step();
 }
 

--- a/rmf_building_sim_gazebo_plugins/src/crowd_simulator.cpp
+++ b/rmf_building_sim_gazebo_plugins/src/crowd_simulator.cpp
@@ -90,10 +90,10 @@ void CrowdSimulatorPlugin::_update(
   }
 
   auto delta_sim_time = (update_info.simTime - _last_sim_time).Double();
-  if (delta_sim_time > _crowd_sim_interface->get_sim_time_step())
+  if (delta_sim_time >= _crowd_sim_interface->get_sim_time_step())
   {
     _last_sim_time = update_info.simTime;
-    _crowd_sim_interface->one_step_sim();
+    _crowd_sim_interface->one_step_sim(delta_sim_time);
     _update_all_objects(delta_sim_time);
   }
 }

--- a/rmf_building_sim_ignition_plugins/src/crowd_simulator.cpp
+++ b/rmf_building_sim_ignition_plugins/src/crowd_simulator.cpp
@@ -97,7 +97,7 @@ void CrowdSimulatorPlugin::PreUpdate(
   if (_crowd_sim_interface->get_sim_time_step() <= delta_sim_time)
   {
     _last_sim_time = info.simTime;
-    _crowd_sim_interface->one_step_sim();
+    _crowd_sim_interface->one_step_sim(delta_sim_time);
     _update_all_objects(delta_sim_time, ecm);
   }
 }
@@ -459,10 +459,10 @@ void CrowdSimulatorPlugin::_update_internal_object(
   traj_pose_comp->Data() = agent_pose;
   ecm.SetChanged(entity,
     ignition::gazebo::components::TrajectoryPose::typeId,
-    ignition::gazebo::ComponentState::OneTimeChange);
+    ignition::gazebo::ComponentState::PeriodicChange);
   ecm.SetChanged(entity,
     ignition::gazebo::components::AnimationTime::typeId,
-    ignition::gazebo::ComponentState::OneTimeChange);
+    ignition::gazebo::ComponentState::PeriodicChange);
 }
 
 } //namespace crowd_simulation_ign

--- a/rmf_building_sim_ignition_plugins/src/crowd_simulator.cpp
+++ b/rmf_building_sim_ignition_plugins/src/crowd_simulator.cpp
@@ -37,7 +37,7 @@ void CrowdSimulatorPlugin::Configure(
   const ignition::gazebo::Entity& entity,
   const std::shared_ptr<const sdf::Element>& sdf,
   ignition::gazebo::EntityComponentManager& ecm,
-  ignition::gazebo::EventManager& event_mgr)
+  ignition::gazebo::EventManager& /*event_mgr*/)
 {
   _world = std::make_shared<ignition::gazebo::Model>(entity);
   RCLCPP_INFO(_crowd_sim_interface->logger(),
@@ -65,7 +65,7 @@ void CrowdSimulatorPlugin::Configure(
     exit(EXIT_FAILURE);
   }
 
-  if (!_spawn_agents_in_world(ecm))
+  if (!_spawn_agents_in_world())
   {
     RCLCPP_ERROR(
       _crowd_sim_interface->logger(),
@@ -103,8 +103,7 @@ void CrowdSimulatorPlugin::PreUpdate(
 }
 
 //==========================================================
-bool CrowdSimulatorPlugin::_spawn_agents_in_world(
-  ignition::gazebo::EntityComponentManager& ecm)
+bool CrowdSimulatorPlugin::_spawn_agents_in_world()
 {
   size_t object_count = this->_crowd_sim_interface->get_num_objects();
   for (size_t id = 0; id < object_count; ++id)
@@ -118,7 +117,7 @@ bool CrowdSimulatorPlugin::_spawn_agents_in_world(
       auto type_ptr = _crowd_sim_interface->_model_type_db_ptr->get(
         object_ptr->type_name);
       assert(type_ptr);
-      if (!this->_create_entity(ecm, object_ptr->model_name, type_ptr) )
+      if (!this->_create_entity(object_ptr->model_name, type_ptr) )
       {
         RCLCPP_ERROR(_crowd_sim_interface->logger(),
           "Failed to insert model [ " + object_ptr->model_name + " ] in world");
@@ -211,7 +210,6 @@ void CrowdSimulatorPlugin::_init_spawned_agents(
 
 //===================================================================
 bool CrowdSimulatorPlugin::_create_entity(
-  ignition::gazebo::EntityComponentManager& ecm,
   const std::string& model_name,
   const crowd_simulator::ModelTypeDatabase::RecordPtr model_type_ptr) const
 {
@@ -412,9 +410,6 @@ void CrowdSimulatorPlugin::_update_internal_object(
       "Model [" + obj_ptr->model_name + "] has no AnimationTime component.");
     exit(EXIT_FAILURE);
   }
-  auto actor_comp =
-    ecm.Component<ignition::gazebo::components::Actor>(entity);
-
   ignition::math::Pose3d current_pose = traj_pose_comp->Data();
   auto distance_traveled_vector = agent_pose.Pos() - current_pose.Pos();
   // might need future work on 3D case

--- a/rmf_building_sim_ignition_plugins/src/crowd_simulator.hpp
+++ b/rmf_building_sim_ignition_plugins/src/crowd_simulator.hpp
@@ -67,14 +67,13 @@ private:
   // map for <model_name, entity_id> contains external and internal agents
   std::unordered_map<std::string, ignition::gazebo::Entity> _entity_dic;
 
-  bool _spawn_agents_in_world(ignition::gazebo::EntityComponentManager& ecm);
+  bool _spawn_agents_in_world();
   void _init_spawned_agents(ignition::gazebo::EntityComponentManager& ecm);
   void _config_spawned_agents(
     const crowd_simulator::CrowdSimInterface::ObjectPtr obj_ptr,
     const ignition::gazebo::Entity& enity,
     ignition::gazebo::EntityComponentManager& ecm) const;
   bool _create_entity(
-    ignition::gazebo::EntityComponentManager& ecm,
     const std::string& model_name,
     const crowd_simulator::ModelTypeDatabase::RecordPtr model_type_ptr) const;
   void _update_all_objects(


### PR DESCRIPTION
## Bug fix

### Fixed bug

When the physics step size was larger than the crowdsim step size, the crowdsim was advanced by the wrong time step, specifically the logic was like:

```
if (delta_t > target_delta_t)
  crowd_sim.advance(target_delta_t)
```

### Fix applied

Crowdsim is now advanced by the correct time step, set at every iteration, basically:

```
if (delta_t > target_delta_t)
  crowd_sim.advance(delta_t)
```

Also added a few performance improvements for Ignition. Because it has excellent actor performance thanks to the actors being animated in the GPU, the step size parameter is ignored altogether and as a result animations are much smoother (the plugin is updated at every iteration).