### PR TITLE
Fix #15

### DIFF
--- a/rmf_robot_sim_common/src/slotcar_common.cpp
+++ b/rmf_robot_sim_common/src/slotcar_common.cpp
@@ -675,6 +675,18 @@ void SlotcarCommon::publish_state_topic(const rclcpp::Time& t)
   robot_state_msg.location.t = t;
   robot_state_msg.location.level_name = get_level_name(_pose.translation()[2]);
 
+  if (robot_state_msg.location.level_name.empty())
+  {
+    RCLCPP_ERROR(
+      logger(),
+      "Unable to determine the current level_name for robot [%s]. Kindly "
+      "ensure the building_map_server is running. The RobotState message for"
+      "this robot will not be published.",
+      _model_name.c_str());
+
+    return;
+  }
+
   robot_state_msg.task_id = _current_task_id;
   robot_state_msg.path = _remaining_path;
   robot_state_msg.mode = _current_mode;


### PR DESCRIPTION
Signed-off-by: Yadunund <yadunund@openrobotics.org>

<!--
For support requests, please read the Support Guidelines to know where to ask: https://github.com/open-rmf/rmf/wiki/Support-guidelines
For general questions and design discussion, please use the Discussions page: https://github.com/open-rmf/rmf/discussions
Not sure if this is the right repository? Open an issue on https://github.com/open-rmf/rmf
We require contributors to GPG Sign their commits. Follow the guide here to set up a GPG key and add it to your GitHub account: https://docs.github.com/en/github/authenticating-to-github/generating-a-new-gpg-key
A quick guide to how to sign your commits can be seen here: https://gist.github.com/mort3za/ad545d47dd2b54970c102fe39912f305
To GPG sign several commits at once (for example, if you forgot to sign some commits), you can run this command, followed by a force-push: git rebase --exec 'git commit --amend --no-edit -n -S' -i <commit before the first commit you want signed>
For bug fix pull requests, please fill out the information below.
Be as detailed as possible.
-->

## Bug fix

### Fixed bug
Fix #15 
<!-- Briefly describe the bug being fixed.
If there is a bug report issue for the bug, link to that issue.
If there is not a bug report issue for the bug, create one first and fill out all the required information there, then link to that issue from this bug fix pull request. -->

### Fix applied
There was an implicit assumption in `slotcar` that the fleet adapters would be launched only after the `building_map_server` is up and running. When this is not the case or in restricted networks, the `slotcar` plugin does not receive the `BuildingMap` message soon enough and hence the `level_name` reported in the `RobotState` would be empty. As a result, computing the `StartSet` for the robot will fail in the fleet adapter.

This PR addresses the problem by not publishing the `RobotState` message if the `level_name` field is empty.



