### PR TITLE
Do not drain battery when robot is at charger waypoint

### DIFF
--- a/rmf_robot_sim_common/src/slotcar_common.cpp
+++ b/rmf_robot_sim_common/src/slotcar_common.cpp
@@ -358,7 +358,7 @@ std::pair<double, double> SlotcarCommon::update(const Eigen::Isometry3d& pose,
       }
     }
     // Discharge battery
-    if (_enable_drain)
+    if (_enable_drain && !in_charger_vicinity)
     {
       const Eigen::Vector3d lin_acc = (lin_vel - _old_lin_vel) / dt;
       const double ang_acc = (ang_vel - _old_ang_vel) / dt;
@@ -667,7 +667,7 @@ void SlotcarCommon::publish_state_topic(const rclcpp::Time& t)
 {
   rmf_fleet_msgs::msg::RobotState robot_state_msg;
   robot_state_msg.name = _model_name;
-  robot_state_msg.battery_percent = 100 * _soc;
+  robot_state_msg.battery_percent = std::ceil(100.0 * _soc);
 
   robot_state_msg.location.x = _pose.translation()[0];
   robot_state_msg.location.y = _pose.translation()[1];


### PR DESCRIPTION
Signed-off-by: Yadunund <yadunund@openrobotics.org>

<!--
For support requests, please read the Support Guidelines to know where to ask: https://github.com/open-rmf/rmf/wiki/Support-guidelines
For general questions and design discussion, please use the Discussions page: https://github.com/open-rmf/rmf/discussions
Not sure if this is the right repository? Open an issue on https://github.com/open-rmf/rmf
We require contributors to GPG Sign their commits. Follow the guide here to set up a GPG key and add it to your GitHub account: https://docs.github.com/en/github/authenticating-to-github/generating-a-new-gpg-key
A quick guide to how to sign your commits can be seen here: https://gist.github.com/mort3za/ad545d47dd2b54970c102fe39912f305
To GPG sign several commits at once (for example, if you forgot to sign some commits), you can run this command, followed by a force-push: git rebase --exec 'git commit --amend --no-edit -n -S' -i <commit before the first commit you want signed>
For bug fix pull requests, please fill out the information below.
Be as detailed as possible.
-->

## Bug fix

### Fixed bug
The `slotcar` plugin would drain the robot's battery even when it is at the charger waypoint. As a result, the battery never really reaches 100.0% but lingers at 99.9999~.

<!-- Briefly describe the bug being fixed.
If there is a bug report issue for the bug, link to that issue.
If there is not a bug report issue for the bug, create one first and fill out all the required information there, then link to that issue from this bug fix pull request. -->

### Fix applied
Do not drain battery when robot is at its charger waypoint.
<!-- Describe in detail the approach taken, tools used, etc. to identify the cause of the bug and what was done to fix it. -->


