### PR TITLE
Make menge mandatory and fix dependencies

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: deps
-        uses: ros-tooling/setup-ros@v0.1
+        uses: ros-tooling/setup-ros@v0.2
         with:
           required-ros-distributions: foxy
       - name: build_and_test

--- a/.github/workflows/tsan.yaml
+++ b/.github/workflows/tsan.yaml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: deps
-        uses: ros-tooling/setup-ros@v0.1
+        uses: ros-tooling/setup-ros@v0.2
         with:
           required-ros-distributions: foxy
       - name: tsan_build_test

--- a/rmf_building_sim_common/CMakeLists.txt
+++ b/rmf_building_sim_common/CMakeLists.txt
@@ -28,7 +28,7 @@ find_package(rmf_fleet_msgs REQUIRED)
 find_package(rmf_door_msgs REQUIRED)
 find_package(rmf_lift_msgs REQUIRED)
 find_package(rmf_building_map_msgs REQUIRED)
-find_package(menge QUIET)
+find_package(menge_vendor REQUIRED)
 
 include(GNUInstallDirs)
 
@@ -92,35 +92,31 @@ target_link_libraries(lift_common
 ###############################
 # crowd simulator stuff
 ###############################
-if (menge_FOUND)
-  add_library(crowd_simulator_common
-    SHARED
-    src/crowd_simulator_common.cpp  
-  )
+add_library(crowd_simulator_common
+  SHARED
+  src/crowd_simulator_common.cpp
+)
 
-  target_include_directories(crowd_simulator_common
-    PUBLIC
-      $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-      $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
-      ${menge_INCLUDE_DIRS}
-  )
-  
-  ament_target_dependencies(crowd_simulator_common
-    menge
-    rclcpp
-  )
+target_include_directories(crowd_simulator_common
+  PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
+    ${menge_vendor_INCLUDE_DIRS}
+)
 
-  #crowd_simulation_common_install
-  ament_export_targets(crowd_simulator_common HAS_LIBRARY_TARGET)
-  install(
-    TARGETS crowd_simulator_common
-    EXPORT crowd_simulator_common
-    LIBRARY DESTINATION lib
-    ARCHIVE DESTINATION lib
-  )
-else(NOT menge_FOUND)
-  message("menge-cmake not found, skipping crowd_simulation plugins")
-endif()
+ament_target_dependencies(crowd_simulator_common
+  menge_vendor
+  rclcpp
+)
+
+#crowd_simulation_common_install
+ament_export_targets(crowd_simulator_common HAS_LIBRARY_TARGET)
+install(
+  TARGETS crowd_simulator_common
+  EXPORT crowd_simulator_common
+  LIBRARY DESTINATION lib
+  ARCHIVE DESTINATION lib
+)
 
 ###############################
 # install stuff

--- a/rmf_building_sim_common/CMakeLists.txt
+++ b/rmf_building_sim_common/CMakeLists.txt
@@ -22,9 +22,6 @@ endif()
 # find dependencies
 find_package(ament_cmake REQUIRED)
 find_package(rclcpp REQUIRED)
-find_package(std_msgs REQUIRED)
-find_package(std_srvs REQUIRED)
-find_package(rmf_fleet_msgs REQUIRED)
 find_package(rmf_door_msgs REQUIRED)
 find_package(rmf_lift_msgs REQUIRED)
 find_package(rmf_building_map_msgs REQUIRED)
@@ -51,7 +48,6 @@ target_include_directories(rmf_building_sim_utils
 add_library(door_common SHARED src/door_common.cpp)
 
 ament_target_dependencies(door_common
-    rmf_fleet_msgs
     rclcpp
     rmf_door_msgs
 )
@@ -73,7 +69,6 @@ target_link_libraries(door_common
 add_library(lift_common SHARED src/lift_common.cpp)
 
 ament_target_dependencies(lift_common
-   rmf_fleet_msgs
    rclcpp
    rmf_door_msgs
    rmf_lift_msgs

--- a/rmf_building_sim_common/QUALITY_DECLARATION.md
+++ b/rmf_building_sim_common/QUALITY_DECLARATION.md
@@ -142,16 +142,6 @@ This quality declaration has not been externally peer-reviewed and is not regist
 `menge_vendor` does not declare a quality level.
 It is assumed to be **Quality Level 4**.
 
-#### qtbase5-dev
-
-`qt5base-dev` is widely-used third-party software for building graphical applications.
-Due to its wide use, documentation, and testing, it is assumed to be **Quality Level 3**.
-
-#### libqt5-widgets
-
-`libqt5-widgets` is widely-used third-party software for building graphical applications.
-Due to its wide use, documentation, and testing, it is assumed to be **Quality Level 3**.
-
 ## Platform Support [6]
 
 `rmf_building_sim_common` does not support all of the tier 1 platforms as described in [REP-2000](https://www.ros.org/reps/rep-2000.html#support-tiers).

--- a/rmf_building_sim_common/QUALITY_DECLARATION.md
+++ b/rmf_building_sim_common/QUALITY_DECLARATION.md
@@ -142,6 +142,16 @@ This quality declaration has not been externally peer-reviewed and is not regist
 `menge_vendor` does not declare a quality level.
 It is assumed to be **Quality Level 4**.
 
+#### qtbase5-dev
+
+`qt5base-dev` is widely-used third-party software for building graphical applications.
+Due to its wide use, documentation, and testing, it is assumed to be **Quality Level 3**.
+
+#### libqt5-widgets
+
+`libqt5-widgets` is widely-used third-party software for building graphical applications.
+Due to its wide use, documentation, and testing, it is assumed to be **Quality Level 3**.
+
 ## Platform Support [6]
 
 `rmf_building_sim_common` does not support all of the tier 1 platforms as described in [REP-2000](https://www.ros.org/reps/rep-2000.html#support-tiers).

--- a/rmf_building_sim_common/QUALITY_DECLARATION.md
+++ b/rmf_building_sim_common/QUALITY_DECLARATION.md
@@ -119,18 +119,6 @@ This quality declaration has not been externally peer-reviewed and is not regist
 
 `rclcpp` is [**Quality Level 1**](https://github.com/ros2/rclcpp/blob/master/rclcpp/QUALITY_DECLARATION.md).
 
-#### std\_msgs
-
-`std_msgs` is [**Quality Level 1**](https://github.com/ros2/common_interfaces/blob/master/std_msgs/QUALITY_DECLARATION.md).
-
-#### std\_srvs
-
-`std_srvs` is [**Quality Level 1**](https://github.com/ros2/common_interfaces/blob/master/std_srvs/QUALITY_DECLARATION.md).
-
-#### rmf\_fleet\_msgs
-
-`rmf_fleet_msgs` is [**Quality Level 3**](https://github.com/open-rmf/rmf_internal_msgs/blob/main/rmf_fleet_msgs/QUALITY_DECLARATION.md).
-
 #### rmf\_door\_msgs
 
 `rmf_door_msgs` is [**Quality Level 3**](https://github.com/open-rmf/rmf_internal_msgs/blob/main/rmf_door_msgs/QUALITY_DECLARATION.md).
@@ -149,20 +137,10 @@ This quality declaration has not been externally peer-reviewed and is not regist
 
 ### Direct Runtime non-ROS Dependency [5.iii]
 
-#### eigen
+#### menge\_vendor
 
-`eigen` does not declare a quality level.
-It is assumed to be **Quality Level 1** based on wide-spread use.
-
-#### menge
-
-`menge` does not declare a quality level.
+`menge_vendor` does not declare a quality level.
 It is assumed to be **Quality Level 4**.
-
-#### Qt5
-
-`Qt5` does not declare a quality level.
-It is assumed to be **Quality Level 1** based on wide-spread use.
 
 ## Platform Support [6]
 

--- a/rmf_building_sim_common/package.xml
+++ b/rmf_building_sim_common/package.xml
@@ -17,9 +17,6 @@
   <buildtool_depend>ament_cmake</buildtool_depend>
 
   <depend>rclcpp</depend>
-  <depend>std_msgs</depend>
-  <depend>std_srvs</depend>
-  <depend>rmf_fleet_msgs</depend>
   <depend>rmf_door_msgs</depend>
   <depend>rmf_lift_msgs</depend>
   <depend>rmf_building_map_msgs</depend>

--- a/rmf_building_sim_common/package.xml
+++ b/rmf_building_sim_common/package.xml
@@ -21,6 +21,8 @@
   <depend>rmf_lift_msgs</depend>
   <depend>rmf_building_map_msgs</depend>
   <depend>menge_vendor</depend>
+  <depend>libqt5-widgets</depend>
+  <depend>qtbase5-dev</depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/rmf_building_sim_common/package.xml
+++ b/rmf_building_sim_common/package.xml
@@ -21,8 +21,6 @@
   <depend>rmf_lift_msgs</depend>
   <depend>rmf_building_map_msgs</depend>
   <depend>menge_vendor</depend>
-  <depend>libqt5-widgets</depend>
-  <depend>qtbase5-dev</depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/rmf_building_sim_common/package.xml
+++ b/rmf_building_sim_common/package.xml
@@ -23,11 +23,7 @@
   <depend>rmf_door_msgs</depend>
   <depend>rmf_lift_msgs</depend>
   <depend>rmf_building_map_msgs</depend>
-
-  <build_depend>eigen</build_depend>
-  <depend>menge</depend>
-  <depend>libqt5-widgets</depend>
-  <depend>qtbase5-dev</depend>
+  <depend>menge_vendor</depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/rmf_building_sim_gazebo_plugins/CMakeLists.txt
+++ b/rmf_building_sim_gazebo_plugins/CMakeLists.txt
@@ -24,20 +24,12 @@ find_package(ament_cmake REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(gazebo REQUIRED)
 find_package(gazebo_ros REQUIRED)
-find_package(gazebo_dev REQUIRED)
 find_package(OpenCV REQUIRED )
-find_package(gazebo_msgs REQUIRED)
-find_package(std_msgs REQUIRED)
-find_package(std_srvs REQUIRED)
 find_package(rmf_fleet_msgs REQUIRED)
 find_package(rmf_door_msgs REQUIRED)
 find_package(rmf_lift_msgs REQUIRED)
-find_package(rmf_building_map_msgs REQUIRED)
 find_package(rmf_building_sim_common REQUIRED)
 find_package(menge_vendor REQUIRED)
-
-# TODO this is a dependency of rmf_building_sim_common, it shouldn't be needed
-#find_package(Eigen3 REQUIRED)
 
 include(GNUInstallDirs)
 
@@ -49,7 +41,6 @@ add_library(door SHARED src/door.cpp)
 
 ament_target_dependencies(door
   rmf_building_sim_common
-  rmf_fleet_msgs
   rclcpp
   gazebo_ros
   rmf_door_msgs
@@ -70,7 +61,6 @@ add_library(lift SHARED src/lift.cpp)
 
 ament_target_dependencies(lift
     rmf_building_sim_common
-    rmf_fleet_msgs
     rclcpp
     gazebo_ros
     rmf_door_msgs
@@ -163,19 +153,12 @@ target_include_directories(crowd_simulator
     ${rmf_building_sim_common_INCLUDE_DIRS}
 )
 
-#install
-install(
-  TARGETS crowd_simulator
-  LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
-  ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
-)
-
 ###############################
 # install stuff
 ###############################
 
 install(
-  TARGETS door lift toggle_floors toggle_charging thumbnail_generator
+  TARGETS door lift toggle_floors toggle_charging thumbnail_generator crowd_simulator
   LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
   ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
 )

--- a/rmf_building_sim_gazebo_plugins/CMakeLists.txt
+++ b/rmf_building_sim_gazebo_plugins/CMakeLists.txt
@@ -34,7 +34,7 @@ find_package(rmf_door_msgs REQUIRED)
 find_package(rmf_lift_msgs REQUIRED)
 find_package(rmf_building_map_msgs REQUIRED)
 find_package(rmf_building_sim_common REQUIRED)
-find_package(menge QUIET)
+find_package(menge_vendor REQUIRED)
 
 # TODO this is a dependency of rmf_building_sim_common, it shouldn't be needed
 #find_package(Eigen3 REQUIRED)
@@ -144,35 +144,31 @@ target_link_libraries(thumbnail_generator
 ###############################
 # crowd simulator stuff
 ###############################
-if (menge_FOUND)
-  add_library(crowd_simulator
-    SHARED
-      src/crowd_simulator.cpp
-  )
+add_library(crowd_simulator
+  SHARED
+    src/crowd_simulator.cpp
+)
 
-  ament_target_dependencies(crowd_simulator
-    rmf_building_sim_common
-    rclcpp
-    menge
-  )
+ament_target_dependencies(crowd_simulator
+  rmf_building_sim_common
+  rclcpp
+  menge_vendor
+)
 
-  target_include_directories(crowd_simulator
-    PUBLIC
-      $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-      ${GAZEBO_INCLUDE_DIRS}
-      ${menge_INCLUDE_DIRS}
-      ${rmf_building_sim_common_INCLUDE_DIRS}   
-  )
+target_include_directories(crowd_simulator
+  PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+    ${GAZEBO_INCLUDE_DIRS}
+    ${menge_vendor_INCLUDE_DIRS}
+    ${rmf_building_sim_common_INCLUDE_DIRS}
+)
 
-  #install
-  install(
-    TARGETS crowd_simulator
-    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
-    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
-  )
-else (NOT menge_FOUND)
-  message("menge-cmake not found, skipping crowd_simulation gazebo plugins")
-endif()
+#install
+install(
+  TARGETS crowd_simulator
+  LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+  ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+)
 
 ###############################
 # install stuff

--- a/rmf_building_sim_gazebo_plugins/QUALITY_DECLARATION.md
+++ b/rmf_building_sim_gazebo_plugins/QUALITY_DECLARATION.md
@@ -121,6 +121,18 @@ This quality declaration has not been externally peer-reviewed and is not regist
 `gazebo_ros` does not declare a Quality Level.
 It is assumed to be at least **Quality Level 4** based on its widespread use.
 
+#### rmf\_fleet\_msgs
+
+`rmf_fleet_msgs` is [**Quality Level 3**](https://github.com/open-rmf/rmf_internal_msgs/blob/main/rmf_fleet_msgs/QUALITY_DECLARATION.md).
+
+#### rmf\_door\_msgs
+
+`rmf_door_msgs` is [**Quality Level 3**](https://github.com/open-rmf/rmf_internal_msgs/blob/main/rmf_door_msgs/QUALITY_DECLARATION.md)
+
+#### rmf\_lift\_msgs
+
+`rmf_lift_msgs` is [**Quality Level 3**](https://github.com/open-rmf/rmf_internal_msgs/blob/main/rmf_lift_msgs/QUALITY_DECLARATION.md)
+
 #### rmf\_building\_sim\_common
 
 `rmf_building_sim_common` is [**Quality Level 4**](../rmf_building_sim_common/QUALITY_DECLARATION.md).
@@ -135,6 +147,26 @@ It is assumed to be at least **Quality Level 4** based on its widespread use.
 
 `OpenCV` does not declare a quality level.
 It is assumed to be **Quality Level 1** based on wide-spread use.
+
+#### gazebo
+
+`gazebos` does not declare a Quality Level.
+It is assumed to be at least **Quality Level 4** based on its widespread use.
+
+#### menge\_vendor
+
+`menge_vendor` does not declare a quality level.
+It is assumed to be **Quality Level 4**.
+
+#### qtbase5-dev
+
+`qt5base-dev` is widely-used third-party software for building graphical applications.
+Due to its wide use, documentation, and testing, it is assumed to be **Quality Level 3**.
+
+#### libqt5-widgets
+
+`libqt5-widgets` is widely-used third-party software for building graphical applications.
+Due to its wide use, documentation, and testing, it is assumed to be **Quality Level 3**.
 
 ## Platform Support [6]
 

--- a/rmf_building_sim_gazebo_plugins/QUALITY_DECLARATION.md
+++ b/rmf_building_sim_gazebo_plugins/QUALITY_DECLARATION.md
@@ -121,16 +121,6 @@ This quality declaration has not been externally peer-reviewed and is not regist
 `gazebo_ros` does not declare a Quality Level.
 It is assumed to be at least **Quality Level 4** based on its widespread use.
 
-#### gazebo\_msgs
-
-`gazebo_ros_msgs` does not declare a Quality Level.
-It is assumed to be at least **Quality Level 4** based on its widespread use.
-
-#### gazebo\_dev
-
-`gazebo_dev` does not declare a Quality Level.
-It is assumed to be at least **Quality Level 4** based on its widespread use.
-
 #### rmf\_building\_sim\_common
 
 `rmf_building_sim_common` is [**Quality Level 4**](../rmf_building_sim_common/QUALITY_DECLARATION.md).

--- a/rmf_building_sim_gazebo_plugins/package.xml
+++ b/rmf_building_sim_gazebo_plugins/package.xml
@@ -20,15 +20,12 @@
   <depend>rclcpp</depend>
   <depend>gazebo</depend>
   <depend>gazebo_ros</depend>
-  <depend>gazebo_msgs</depend>
-  <depend>gazebo_dev</depend>
   <depend>libopencv-dev</depend>
   <depend>std_msgs</depend>
   <depend>std_srvs</depend>
   <depend>rmf_fleet_msgs</depend>
   <depend>rmf_door_msgs</depend>
   <depend>rmf_lift_msgs</depend>
-  <depend>rmf_building_map_msgs</depend>
   <depend>rmf_building_sim_common</depend>
   <depend>menge_vendor</depend>
 

--- a/rmf_building_sim_gazebo_plugins/package.xml
+++ b/rmf_building_sim_gazebo_plugins/package.xml
@@ -17,12 +17,21 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
+  <depend>rclcpp</depend>
+  <depend>gazebo</depend>
   <depend>gazebo_ros</depend>
   <depend>gazebo_msgs</depend>
   <depend>gazebo_dev</depend>
   <depend>libopencv-dev</depend>
-
+  <depend>std_msgs</depend>
+  <depend>std_srvs</depend>
+  <depend>rmf_fleet_msgs</depend>
+  <depend>rmf_door_msgs</depend>
+  <depend>rmf_lift_msgs</depend>
+  <depend>rmf_building_map_msgs</depend>
   <depend>rmf_building_sim_common</depend>
+  <depend>menge_vendor</depend>
+
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/rmf_building_sim_gazebo_plugins/package.xml
+++ b/rmf_building_sim_gazebo_plugins/package.xml
@@ -21,14 +21,13 @@
   <depend>gazebo</depend>
   <depend>gazebo_ros</depend>
   <depend>libopencv-dev</depend>
-  <depend>std_msgs</depend>
-  <depend>std_srvs</depend>
   <depend>rmf_fleet_msgs</depend>
   <depend>rmf_door_msgs</depend>
   <depend>rmf_lift_msgs</depend>
   <depend>rmf_building_sim_common</depend>
   <depend>menge_vendor</depend>
-
+  <depend>libqt5-widgets</depend>
+  <depend>qtbase5-dev</depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/rmf_building_sim_ignition_plugins/CMakeLists.txt
+++ b/rmf_building_sim_ignition_plugins/CMakeLists.txt
@@ -62,7 +62,7 @@ find_package (Qt5
     Quick
   REQUIRED
 )
-find_package(menge QUIET)
+find_package(menge_vendor REQUIRED)
 
 include(GNUInstallDirs)
 
@@ -117,38 +117,34 @@ ament_target_dependencies(lift
 ###############################
 # crowd simulator stuff
 ###############################
-if (menge_FOUND)
-  add_library(crowd_simulator
-    SHARED
-    src/crowd_simulator.cpp
-  )
+add_library(crowd_simulator
+  SHARED
+  src/crowd_simulator.cpp
+)
 
-  target_include_directories(crowd_simulator
-    PUBLIC
-    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-    ${rmf_building_sim_common_INCLUDE_DIRS}
-    ${rclcpp_INCLUDE_DIRS}
-    ${menge_INCLUDE_DIRS}
-    ${IGNITION-COMMON_INCLUDE_DIRS}
-  )
+target_include_directories(crowd_simulator
+  PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+  ${rmf_building_sim_common_INCLUDE_DIRS}
+  ${rclcpp_INCLUDE_DIRS}
+  ${menge_vendor_INCLUDE_DIRS}
+  ${IGNITION-COMMON_INCLUDE_DIRS}
+)
 
-  ament_target_dependencies(crowd_simulator
-    ignition-gazebo${IGN_GAZEBO_VER}
-    ignition-plugin${IGN_PLUGIN_VER}
-    rclcpp
-    rmf_building_sim_common
-    menge
-  )
+ament_target_dependencies(crowd_simulator
+  ignition-gazebo${IGN_GAZEBO_VER}
+  ignition-plugin${IGN_PLUGIN_VER}
+  rclcpp
+  rmf_building_sim_common
+  menge_vendor
+)
 
-  #install
-  install(
-    TARGETS crowd_simulator
-    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
-    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
-  )
-else (NOT menge_FOUND)
-  message("menge-cmake not found, skipping crowd_simulation ignition plugins")
-endif()
+#install
+install(
+  TARGETS crowd_simulator
+  LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+  ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+)
 
 ###############################
 # toggle charging

--- a/rmf_building_sim_ignition_plugins/CMakeLists.txt
+++ b/rmf_building_sim_ignition_plugins/CMakeLists.txt
@@ -48,12 +48,8 @@ ign_find_package(ignition-transport10 REQUIRED)
 set(IGN_TRANSPORT_VER 10)
 ign_find_package(sdformat11 REQUIRED)
 
-find_package(std_msgs REQUIRED)
-find_package(std_srvs REQUIRED)
-find_package(rmf_fleet_msgs REQUIRED)
 find_package(rmf_door_msgs REQUIRED)
 find_package(rmf_lift_msgs REQUIRED)
-find_package(rmf_building_map_msgs REQUIRED)
 find_package(rmf_building_sim_common REQUIRED)
 find_package (Qt5
   COMPONENTS
@@ -86,7 +82,6 @@ ament_target_dependencies(door
     ignition-plugin${IGN_PLUGIN_VER}
     rmf_building_sim_common
     rmf_door_msgs
-    rmf_fleet_msgs
 )
 
 ###############################
@@ -111,7 +106,6 @@ ament_target_dependencies(lift
     rmf_building_sim_common
     rmf_door_msgs
     rmf_lift_msgs
-    rmf_fleet_msgs
 )
 
 ###############################
@@ -137,13 +131,6 @@ ament_target_dependencies(crowd_simulator
   rclcpp
   rmf_building_sim_common
   menge_vendor
-)
-
-#install
-install(
-  TARGETS crowd_simulator
-  LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
-  ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
 )
 
 ###############################
@@ -179,7 +166,7 @@ target_include_directories(toggle_charging
 ###############################
 
 install(
-  TARGETS door lift toggle_charging
+  TARGETS door lift crowd_simulator toggle_charging
   LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
   ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
 )

--- a/rmf_building_sim_ignition_plugins/QUALITY_DECLARATION.md
+++ b/rmf_building_sim_ignition_plugins/QUALITY_DECLARATION.md
@@ -112,13 +112,45 @@ This quality declaration has not been externally peer-reviewed and is not regist
 
 `rmf_building_sim_ignition_plugins` has the following direct runtime ROS dependencies.
 
+#### rclcpp
+
+`rclcpp` is [**Quality Level 1**](https://github.com/ros2/rclcpp/blob/master/rclcpp/QUALITY_DECLARATION.md).
+
+#### rmf\_door\_msgs
+
+`rmf_door_msgs` is [**Quality Level 3**](https://github.com/open-rmf/rmf_internal_msgs/blob/main/rmf_door_msgs/QUALITY_DECLARATION.md).
+
+#### rmf\_lift\_msgs
+
+`rmf_lift_msgs` is [**Quality Level 3**](https://github.com/open-rmf/rmf_internal_msgs/blob/main/rmf_lift_msgs/QUALITY_DECLARATION.md).
+
 #### rmf\_building\_sim\_common
 
 `rmf_building_sim_common` is [**Quality Level 4**](../rmf_building_sim_common/QUALITY_DECLARATION.md).
 
 ### Optional Direct Runtime ROS Dependencies [5.ii]
 
-`rmf_building_sim_ignition_plugins` does not have any optional direct runtime ROS dependencies.
+This package has the following runtime non-ROS dependencies.
+
+#### libqt5-core
+
+`libqt5-core` is widely-used third-party software for building graphical applications.
+Due to its wide use, documentation, and testing, it is assumed to be **Quality Level 3**.
+
+#### libqt5-qml
+
+`libqt5-qml` is widely-used third-party software for building graphical applications.
+Due to its wide use, documentation, and testing, it is assumed to be **Quality Level 3**.
+
+#### libqt5-quick
+
+`libqt5-quick` is widely-used third-party software for building graphical applications.
+Due to its wide use, documentation, and testing, it is assumed to be **Quality Level 3**.
+
+#### menge\_vendor
+
+`menge_vendor` does not declare a quality level.
+It is assumed to be **Quality Level 4**.
 
 ### Direct Runtime non-ROS Dependency [5.iii]
 

--- a/rmf_building_sim_ignition_plugins/package.xml
+++ b/rmf_building_sim_ignition_plugins/package.xml
@@ -18,7 +18,7 @@
   <depend>rmf_building_sim_common</depend>
   <depend>libqt5-core</depend>
   <depend>libqt5-qml</depend>
-  <depend>libqt5-quick;w</depend>
+  <depend>libqt5-quick</depend>
   <depend>menge_vendor</depend>
 
   <export>

--- a/rmf_building_sim_ignition_plugins/package.xml
+++ b/rmf_building_sim_ignition_plugins/package.xml
@@ -12,7 +12,18 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
+  <depend>rclcpp</depend>
+  <depend>std_msgs</depend>
+  <depend>std_srvs</depend>
+  <depend>rmf_fleet_msgs</depend>
+  <depend>rmf_door_msgs</depend>
+  <depend>rmf_lift_msgs</depend>
+  <depend>rmf_building_map_msgs</depend>
   <depend>rmf_building_sim_common</depend>
+  <depend>libqt5-core</depend>
+  <depend>libqt5-qml</depend>
+  <depend>libqt5-quick;w</depend>
+  <depend>menge_vendor</depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/rmf_building_sim_ignition_plugins/package.xml
+++ b/rmf_building_sim_ignition_plugins/package.xml
@@ -13,12 +13,8 @@
   <buildtool_depend>ament_cmake</buildtool_depend>
 
   <depend>rclcpp</depend>
-  <depend>std_msgs</depend>
-  <depend>std_srvs</depend>
-  <depend>rmf_fleet_msgs</depend>
   <depend>rmf_door_msgs</depend>
   <depend>rmf_lift_msgs</depend>
-  <depend>rmf_building_map_msgs</depend>
   <depend>rmf_building_sim_common</depend>
   <depend>libqt5-core</depend>
   <depend>libqt5-qml</depend>


### PR DESCRIPTION
Related to https://github.com/open-rmf/menge_vendor/pull/8

## Bug fix

### Fixed bug

- Changing name of `menge` to `menge_vendor` as per `ROS` releasing policies
- Making `menge_vendor` not optional as it's mandatory on the `package.xml` anyway
- Making dependencies of the rmf simulation plugins
