### PR TITLE
Removing unnecessary qt5 dependency from CMakeLists

### DIFF
--- a/rmf_building_sim_common/CMakeLists.txt
+++ b/rmf_building_sim_common/CMakeLists.txt
@@ -1,9 +1,6 @@
 cmake_minimum_required(VERSION 3.5)
 project(rmf_building_sim_common)
 
-find_package(Qt5 COMPONENTS Widgets REQUIRED)
-set(CMAKE_AUTOMOC ON)
-
 # Default to C99
 if(NOT CMAKE_C_STANDARD)
   set(CMAKE_C_STANDARD 99)


### PR DESCRIPTION
Signed-off-by: Marco A. Gutierrez <marco@openrobotics.org>