### PR TITLE
Fix/dependencies

### DIFF
--- a/rmf_building_sim_common/CMakeLists.txt
+++ b/rmf_building_sim_common/CMakeLists.txt
@@ -113,6 +113,13 @@ install(
 ###############################
 # install stuff
 ###############################
+ament_export_dependencies(
+  rclcpp
+  rmf_door_msgs
+  rmf_lift_msgs
+  rmf_building_map_msgs
+  menge_vendor
+)
 
 ament_export_include_directories(include)
 ament_export_targets(rmf_building_sim_utils HAS_LIBRARY_TARGET)

--- a/rmf_building_sim_common/package.xml
+++ b/rmf_building_sim_common/package.xml
@@ -12,6 +12,7 @@
   <author>Kevin Ma</author>
   <author>Rushyendra Maganty</author>
   <maintainer email="morgan@openrobotics.org">Morgan Quigley</maintainer>
+  <maintainer email="marco@openrobotics.org">Marco A. Gutiérrez</maintainer>
   <license>Apache 2.0</license>
 
   <buildtool_depend>ament_cmake</buildtool_depend>

--- a/rmf_building_sim_gazebo_plugins/CMakeLists.txt
+++ b/rmf_building_sim_gazebo_plugins/CMakeLists.txt
@@ -22,12 +22,10 @@ endif()
 # find dependencies
 find_package(ament_cmake REQUIRED)
 find_package(rclcpp REQUIRED)
-find_package(gazebo REQUIRED)
+find_package(gazebo_dev REQUIRED)
 find_package(gazebo_ros REQUIRED)
 find_package(OpenCV REQUIRED )
 find_package(rmf_fleet_msgs REQUIRED)
-find_package(rmf_door_msgs REQUIRED)
-find_package(rmf_lift_msgs REQUIRED)
 find_package(rmf_building_sim_common REQUIRED)
 find_package(menge_vendor REQUIRED)
 
@@ -43,7 +41,6 @@ ament_target_dependencies(door
   rmf_building_sim_common
   rclcpp
   gazebo_ros
-  rmf_door_msgs
 )
 
 target_include_directories(door
@@ -63,8 +60,6 @@ ament_target_dependencies(lift
     rmf_building_sim_common
     rclcpp
     gazebo_ros
-    rmf_door_msgs
-    rmf_lift_msgs
 )
 
 target_include_directories(lift

--- a/rmf_building_sim_gazebo_plugins/QUALITY_DECLARATION.md
+++ b/rmf_building_sim_gazebo_plugins/QUALITY_DECLARATION.md
@@ -116,6 +116,11 @@ This quality declaration has not been externally peer-reviewed and is not regist
 
 `rclcpp` is [**Quality Level 1**](https://github.com/ros2/rclcpp/blob/master/rclcpp/QUALITY_DECLARATION.md).
 
+#### gazebo\_dev
+
+`gazebo_dev` does not declare a Quality Level.
+It is assumed to be at least **Quality Level 4** based on its widespread use.
+
 #### gazebo\_ros
 
 `gazebo_ros` does not declare a Quality Level.
@@ -124,14 +129,6 @@ It is assumed to be at least **Quality Level 4** based on its widespread use.
 #### rmf\_fleet\_msgs
 
 `rmf_fleet_msgs` is [**Quality Level 3**](https://github.com/open-rmf/rmf_internal_msgs/blob/main/rmf_fleet_msgs/QUALITY_DECLARATION.md).
-
-#### rmf\_door\_msgs
-
-`rmf_door_msgs` is [**Quality Level 3**](https://github.com/open-rmf/rmf_internal_msgs/blob/main/rmf_door_msgs/QUALITY_DECLARATION.md)
-
-#### rmf\_lift\_msgs
-
-`rmf_lift_msgs` is [**Quality Level 3**](https://github.com/open-rmf/rmf_internal_msgs/blob/main/rmf_lift_msgs/QUALITY_DECLARATION.md)
 
 #### rmf\_building\_sim\_common
 
@@ -147,11 +144,6 @@ It is assumed to be at least **Quality Level 4** based on its widespread use.
 
 `OpenCV` does not declare a quality level.
 It is assumed to be **Quality Level 1** based on wide-spread use.
-
-#### gazebo
-
-`gazebos` does not declare a Quality Level.
-It is assumed to be at least **Quality Level 4** based on its widespread use.
 
 #### menge\_vendor
 

--- a/rmf_building_sim_gazebo_plugins/package.xml
+++ b/rmf_building_sim_gazebo_plugins/package.xml
@@ -13,6 +13,7 @@
   <author>Kevin Ma</author>
   <author>Rushyendra Maganty</author>
   <maintainer email="morgan@openrobotics.org">Morgan Quigley</maintainer>
+  <maintainer email="marco@openrobotics.org">Marco A. Gutiérrez</maintainer>
   <license>Apache 2.0</license>
 
   <buildtool_depend>ament_cmake</buildtool_depend>

--- a/rmf_building_sim_gazebo_plugins/package.xml
+++ b/rmf_building_sim_gazebo_plugins/package.xml
@@ -18,12 +18,10 @@
   <buildtool_depend>ament_cmake</buildtool_depend>
 
   <depend>rclcpp</depend>
-  <depend>gazebo</depend>
+  <depend>gazebo_dev</depend>
   <depend>gazebo_ros</depend>
   <depend>libopencv-dev</depend>
   <depend>rmf_fleet_msgs</depend>
-  <depend>rmf_door_msgs</depend>
-  <depend>rmf_lift_msgs</depend>
   <depend>rmf_building_sim_common</depend>
   <depend>menge_vendor</depend>
   <depend>libqt5-widgets</depend>

--- a/rmf_building_sim_ignition_plugins/CMakeLists.txt
+++ b/rmf_building_sim_ignition_plugins/CMakeLists.txt
@@ -48,8 +48,6 @@ ign_find_package(ignition-transport10 REQUIRED)
 set(IGN_TRANSPORT_VER 10)
 ign_find_package(sdformat11 REQUIRED)
 
-find_package(rmf_door_msgs REQUIRED)
-find_package(rmf_lift_msgs REQUIRED)
 find_package(rmf_building_sim_common REQUIRED)
 find_package (Qt5
   COMPONENTS
@@ -81,7 +79,6 @@ ament_target_dependencies(door
     ignition-gazebo${IGN_GAZEBO_VER}
     ignition-plugin${IGN_PLUGIN_VER}
     rmf_building_sim_common
-    rmf_door_msgs
 )
 
 ###############################
@@ -94,8 +91,6 @@ target_include_directories(lift
   PUBLIC
     ${rmf_building_sim_common_INCLUDE_DIRS}
     ${geometry_msgs_INCLUDE_DIRS}
-    ${rmf_door_msgs_INCLUDE_DIRS}
-    ${rmf_lift_msgs_INCLUDE_DIRS}
 )
 
 ament_target_dependencies(lift
@@ -104,8 +99,6 @@ ament_target_dependencies(lift
     ignition-gazebo${IGN_GAZEBO_VER}
     ignition-plugin${IGN_PLUGIN_VER}
     rmf_building_sim_common
-    rmf_door_msgs
-    rmf_lift_msgs
 )
 
 ###############################

--- a/rmf_building_sim_ignition_plugins/QUALITY_DECLARATION.md
+++ b/rmf_building_sim_ignition_plugins/QUALITY_DECLARATION.md
@@ -116,14 +116,6 @@ This quality declaration has not been externally peer-reviewed and is not regist
 
 `rclcpp` is [**Quality Level 1**](https://github.com/ros2/rclcpp/blob/master/rclcpp/QUALITY_DECLARATION.md).
 
-#### rmf\_door\_msgs
-
-`rmf_door_msgs` is [**Quality Level 3**](https://github.com/open-rmf/rmf_internal_msgs/blob/main/rmf_door_msgs/QUALITY_DECLARATION.md).
-
-#### rmf\_lift\_msgs
-
-`rmf_lift_msgs` is [**Quality Level 3**](https://github.com/open-rmf/rmf_internal_msgs/blob/main/rmf_lift_msgs/QUALITY_DECLARATION.md).
-
 #### rmf\_building\_sim\_common
 
 `rmf_building_sim_common` is [**Quality Level 4**](../rmf_building_sim_common/QUALITY_DECLARATION.md).
@@ -131,6 +123,46 @@ This quality declaration has not been externally peer-reviewed and is not regist
 ### Optional Direct Runtime ROS Dependencies [5.ii]
 
 This package has the following runtime non-ROS dependencies.
+
+#### ignition-gazebo
+
+`ignition-gazebo` does not declare a quality level.
+It is assumed to be at least **Quality Level 3** based on its history, use of CI, and use of testing.
+
+#### ignition-plugin
+
+`ignition-plugin` does not declare a quality level.
+It is assumed to be at least **Quality Level 3** based on its history, use of CI, and use of testing.
+
+#### ignition-common
+
+`ignition-common` does not declare a quality level.
+It is assumed to be at least **Quality Level 3** based on its history, use of CI, and use of testing.
+
+#### ignition-math
+
+`ignition-math` does not declare a quality level.
+It is assumed to be at least **Quality Level 3** based on its history, use of CI, and use of testing.
+
+#### ignition-gui
+
+`ignition-gui` does not declare a quality level.
+It is assumed to be at least **Quality Level 3** based on its history, use of CI, and use of testing.
+
+#### ignition-msgs
+
+`ignition-msgs` does not declare a quality level.
+It is assumed to be at least **Quality Level 3** based on its history, use of CI, and use of testing.
+
+#### ignition-transport
+
+`ignition-transport` does not declare a quality level.
+It is assumed to be at least **Quality Level 3** based on its history, use of CI, and use of testing.
+
+#### sdformat11
+
+`sdformat11` does not declare a quality level.
+It is assumed to be at least **Quality Level 3** based on its history, use of CI, and use of testing.
 
 #### libqt5-core
 

--- a/rmf_building_sim_ignition_plugins/package.xml
+++ b/rmf_building_sim_ignition_plugins/package.xml
@@ -8,6 +8,7 @@
   <author>Kevin Ma</author>
   <author>Rushyendra Maganty</author>
   <maintainer email="luca@openrobotics.org">Luca Della Vedova</maintainer>
+  <maintainer email="marco@openrobotics.org">Marco A. Gutiérrez</maintainer>
   <license>Apache 2.0</license>
 
   <buildtool_depend>ament_cmake</buildtool_depend>

--- a/rmf_building_sim_ignition_plugins/package.xml
+++ b/rmf_building_sim_ignition_plugins/package.xml
@@ -13,8 +13,6 @@
   <buildtool_depend>ament_cmake</buildtool_depend>
 
   <depend>rclcpp</depend>
-  <depend>rmf_door_msgs</depend>
-  <depend>rmf_lift_msgs</depend>
   <depend>rmf_building_sim_common</depend>
   <depend>libqt5-core</depend>
   <depend>libqt5-qml</depend>

--- a/rmf_robot_sim_common/CMakeLists.txt
+++ b/rmf_robot_sim_common/CMakeLists.txt
@@ -133,7 +133,6 @@ target_include_directories(slotcar_common
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
     $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
     ${EIGEN3_INCLUDE_DIRS}
-    ${GAZEBO_INCLUDE_DIRS}
 )
 
 target_link_libraries(slotcar_common
@@ -143,7 +142,18 @@ target_link_libraries(slotcar_common
 ###############################
 # Install Targets             #
 ###############################
-ament_export_dependencies(Eigen3)
+ament_export_dependencies(
+  Eigen3
+  rclcpp
+  geometry_msgs
+  std_msgs
+  tf2_ros
+  rmf_fleet_msgs
+  rmf_dispenser_msgs
+  rmf_ingestor_msgs
+  rmf_building_map_msgs
+)
+
 ament_export_include_directories(include)
 ament_export_targets(ingestor_common HAS_LIBRARY_TARGET)
 ament_export_targets(dispenser_common HAS_LIBRARY_TARGET)

--- a/rmf_robot_sim_common/QUALITY_DECLARATION.md
+++ b/rmf_robot_sim_common/QUALITY_DECLARATION.md
@@ -116,6 +116,10 @@ This package has the following direct runtime ROS dependencies.
 
 `rclcpp` is [**Quality Level 1**](https://github.com/ros2/rclcpp/blob/master/rclcpp/QUALITY_DECLARATION.md).
 
+#### geometry\_msgs
+
+`geometry_msgs` is [**Quality Level 1**](https://github.com/ros2/common_interfaces/blob/master/geometry_msgs/QUALITY_DECLARATION.md).
+
 #### std\_msgs
 
 `std_msgs` is [**Quality Level 1**](https://github.com/ros2/common_interfaces/blob/master/std_msgs/QUALITY_DECLARATION.md).

--- a/rmf_robot_sim_common/package.xml
+++ b/rmf_robot_sim_common/package.xml
@@ -7,6 +7,7 @@
   <author>Aaron Chong</author>
   <author>Rushyendra Maganty</author>
   <maintainer email="luca@openrobotics.org">Luca Della Vedova</maintainer>
+  <maintainer email="marco@openrobotics.org">Marco A. Gutiérrez</maintainer>
   <license>Apache 2.0</license>
 
   <buildtool_depend>ament_cmake</buildtool_depend>

--- a/rmf_robot_sim_common/package.xml
+++ b/rmf_robot_sim_common/package.xml
@@ -12,7 +12,6 @@
   <buildtool_depend>ament_cmake</buildtool_depend>
 
   <depend>eigen</depend>
-
   <depend>rclcpp</depend>
   <depend>geometry_msgs</depend>
   <depend>std_msgs</depend>

--- a/rmf_robot_sim_gazebo_plugins/CMakeLists.txt
+++ b/rmf_robot_sim_gazebo_plugins/CMakeLists.txt
@@ -19,17 +19,11 @@ endif()
 # find dependencies
 find_package(ament_cmake REQUIRED)
 find_package(rclcpp REQUIRED)
-find_package(gazebo REQUIRED)
 find_package(gazebo_ros REQUIRED)
 find_package(gazebo_dev REQUIRED)
-find_package(gazebo_msgs REQUIRED)
 find_package(Eigen3 REQUIRED)
 find_package(geometry_msgs REQUIRED)
-find_package(std_msgs REQUIRED)
-find_package(tf2_ros REQUIRED)
 find_package(rmf_fleet_msgs REQUIRED)
-find_package(rmf_dispenser_msgs REQUIRED)
-find_package(rmf_ingestor_msgs REQUIRED)
 find_package(rmf_building_map_msgs REQUIRED)
 find_package(rmf_robot_sim_common REQUIRED)
 
@@ -45,7 +39,6 @@ ament_target_dependencies(teleport_dispenser
   rclcpp
   gazebo_ros
   rmf_fleet_msgs
-  rmf_dispenser_msgs
   rmf_robot_sim_common
   Eigen3
 )
@@ -68,7 +61,6 @@ ament_target_dependencies(teleport_ingestor
   rclcpp
   gazebo_ros
   rmf_fleet_msgs
-  rmf_ingestor_msgs
   rmf_robot_sim_common
   Eigen3
 )
@@ -116,9 +108,7 @@ ament_target_dependencies(slotcar
   rmf_fleet_msgs
   rclcpp
   gazebo_ros
-  std_msgs
   geometry_msgs
-  tf2_ros
   rmf_building_map_msgs
 )
 

--- a/rmf_robot_sim_gazebo_plugins/QUALITY_DECLARATION.md
+++ b/rmf_robot_sim_gazebo_plugins/QUALITY_DECLARATION.md
@@ -112,14 +112,36 @@ This package does not use the standard linters and static analysis tools for its
 
 This package has the following direct runtime ROS dependencies.
 
-#### gazebo\_ros\_pkgs
+#### rclcpp
 
-`gazebo_ros_pkgs` does not declare a Quality Level.
+`rclcpp` is [**Quality Level 1**](https://github.com/ros2/rclcpp/blob/master/rclcpp/QUALITY_DECLARATION.md).
+
+#### gazebo\_dev
+
+`gazebo_dev` does not declare a Quality Level.
+It is assumed to be at least **Quality Level 4** based on its widespread use.
+
+
+#### gazebo\_ros
+
+`gazebo_ros` does not declare a Quality Level.
 It is assumed to be at least **Quality Level 4** based on its widespread use.
 
 #### rmf\_robot\_sim\_common
 
 `rmf_robot_sim_common` is [**Quality Level 4**](https://github.com/open-rmf/rmf_simulation/blob/main/rmf_robot_sim_common/QUALITY_DECLARATION.md).
+
+#### rmf\_fleet\_msgs
+
+`rmf_fleet_msgs` is [**Quality Level 3**](https://github.com/open-rmf/rmf_internal_msgs/blob/main/rmf_fleet_msgs/QUALITY_DECLARATION.md).
+
+#### rmf\_building\_map\_msgs
+
+`rmf_building_map_msgs` is [**Quality Level 3**](https://github.com/open-rmf/rmf_building_map_msgs/blob/main/rmf_building_map_msgs/QUALITY_DECLARATION.md).
+
+#### geometry\_msgs
+
+`gemoetry_msgs` is [**Quality Level 1**](https://github.com/ros2/common_interfaces/blob/master/geometry_msgs/QUALITY_DECLARATION.md).
 
 ### Optional Direct Runtime ROS Dependencies [5.ii]
 
@@ -127,7 +149,12 @@ This package does not have any optional direct runtime ROS dependencies.
 
 ### Direct Runtime non-ROS Dependency [5.iii]
 
-This package has no direct runtime non-ROS dependencies.
+This package has the following runtime non-ROS dependencies.
+
+#### eigen
+
+`eigen` does not declare a quality level.
+It is assumed to be QL1 based on wide-spread use.
 
 ## Platform Support [6]
 

--- a/rmf_robot_sim_gazebo_plugins/package.xml
+++ b/rmf_robot_sim_gazebo_plugins/package.xml
@@ -13,8 +13,15 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
-  <depend>gazebo_ros_pkgs</depend>
+  <depend>rclcpp</depend>
+  <depend>gazebo-dev</depend>
+  <depend>gazebo_ros</depend>
+  <depend>eigen</depend>
+  <depend>geometry_msgs</depend>
+  <depend>rmf_fleet_msgs</depend>
+  <depend>rmf_building_map_msgs</depend>
   <depend>rmf_robot_sim_common</depend>
+
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/rmf_robot_sim_gazebo_plugins/package.xml
+++ b/rmf_robot_sim_gazebo_plugins/package.xml
@@ -9,6 +9,7 @@
   <author>Aaron Chong</author>
   <author>Rushyendra Maganty</author>
   <maintainer email="luca@openrobotics.org">Luca Della Vedova</maintainer>
+  <maintainer email="marco@openrobotics.org">Marco A. Gutiérrez</maintainer>
   <license>Apache 2.0</license>
 
   <buildtool_depend>ament_cmake</buildtool_depend>

--- a/rmf_robot_sim_ignition_plugins/CMakeLists.txt
+++ b/rmf_robot_sim_ignition_plugins/CMakeLists.txt
@@ -52,12 +52,7 @@ set(IGN_RENDERING_VER 5)
 ign_find_package(sdformat11 REQUIRED)
 
 find_package(Eigen3 REQUIRED)
-find_package(geometry_msgs REQUIRED)
-find_package(std_msgs REQUIRED)
-find_package(tf2_ros REQUIRED)
 find_package(rmf_fleet_msgs REQUIRED)
-find_package(rmf_dispenser_msgs REQUIRED)
-find_package(rmf_ingestor_msgs REQUIRED)
 find_package(rmf_building_map_msgs REQUIRED)
 find_package(rmf_robot_sim_common REQUIRED)
 find_package (Qt5
@@ -82,7 +77,6 @@ ament_target_dependencies(teleport_ingestor
     ignition-msgs${IGN_MSGS_VER}
     ignition-transport${IGN_TRANSPORT_VER}
     rmf_fleet_msgs
-    rmf_ingestor_msgs
     rclcpp
     rmf_robot_sim_common
     Eigen3
@@ -107,7 +101,6 @@ ament_target_dependencies(teleport_dispenser
     ignition-msgs${IGN_MSGS_VER}
     ignition-transport${IGN_TRANSPORT_VER}
     rmf_fleet_msgs
-    rmf_dispenser_msgs
     rclcpp
     rmf_robot_sim_common
     Eigen3
@@ -156,8 +149,6 @@ ament_target_dependencies(slotcar
     rmf_robot_sim_common
     rmf_fleet_msgs
     rclcpp
-    geometry_msgs
-    tf2_ros
 )
 
 target_include_directories(slotcar
@@ -165,11 +156,8 @@ target_include_directories(slotcar
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
     $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
     ${rmf_robot_sim_common_INCLUDE_DIRS}
-    ${geometry_msgs_INCLUDE_DIRS}
-    ${std_msgs_INCLUDE_DIRS}
     ${rmf_fleet_msgs_INCLUDE_DIRS}
     ${rmf_building_map_msgs_INCLUDE_DIRS}
-    ${tf2_ros_INCLUDE_DIRS}
 )
 
 ###############################

--- a/rmf_robot_sim_ignition_plugins/QUALITY_DECLARATION.md
+++ b/rmf_robot_sim_ignition_plugins/QUALITY_DECLARATION.md
@@ -112,6 +112,18 @@ This package does not use the standard linters and static analysis tools for its
 
 This package has the following direct runtime ROS dependencies.
 
+#### rclcpp
+
+`rclcpp` is [**Quality Level 1**](https://github.com/ros2/rclcpp/blob/master/rclcpp/QUALITY_DECLARATION.md).
+
+#### rmf\_fleet\_msgs
+
+`rmf_fleet_msgs` is [**Quality Level 3**](https://github.com/open-rmf/rmf_internal_msgs/blob/main/rmf_fleet_msgs/QUALITY_DECLARATION.md).
+
+#### rmf\_building\_map\_msgs
+
+`rmf_building_map_msgs` is [**Quality Level 3**](https://github.com/open-rmf/rmf_building_map_msgs/blob/main/rmf_building_map_msgs/QUALITY_DECLARATION.md).
+
 #### rmf\_robot\_sim\_common
 
 `rmf_robot_sim_common` is [**Quality Level 4**](https://github.com/open-rmf/rmf_simulation/blob/master/rmf_robot_sim_common/QUALITY_DECLARATION.md).
@@ -123,6 +135,11 @@ This package does not have any optional direct runtime ROS dependencies.
 ### Direct Runtime non-ROS Dependency [5.iii]
 
 This package has the following runtime non-ROS dependencies.
+
+#### eigen
+
+`eigen` does not declare a quality level.
+It is assumed to be QL1 based on wide-spread use.
 
 #### ignition-gazebo
 
@@ -163,6 +180,26 @@ It is assumed to be at least **Quality Level 3** based on its history, use of CI
 
 `ignition-rendering` does not declare a quality level.
 It is assumed to be at least **Quality Level 3** based on its history, use of CI, and use of testing.
+
+#### sdformat11
+
+`sdformat11` does not declare a quality level.
+It is assumed to be at least **Quality Level 3** based on its history, use of CI, and use of testing.
+
+#### libqt5-core
+
+`libqt5-core` is widely-used third-party software for building graphical applications.
+Due to its wide use, documentation, and testing, it is assumed to be **Quality Level 3**.
+
+#### libqt5-qml
+
+`libqt5-qml` is widely-used third-party software for building graphical applications.
+Due to its wide use, documentation, and testing, it is assumed to be **Quality Level 3**.
+
+#### libqt5-quick
+
+`libqt5-quick` is widely-used third-party software for building graphical applications.
+Due to its wide use, documentation, and testing, it is assumed to be **Quality Level 3**.
 
 ## Platform Support [6]
 

--- a/rmf_robot_sim_ignition_plugins/package.xml
+++ b/rmf_robot_sim_ignition_plugins/package.xml
@@ -13,7 +13,14 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
+  <depend>rclcpp</depend>
+  <depend>eigen</depend>
+  <depend>rmf_fleet_msgs</depend>
+  <depend>rmf_building_map_msgs</depend>
   <depend>rmf_robot_sim_common</depend>
+  <depend>libqt5-core</depend>
+  <depend>libqt5-qml</depend>
+  <depend>libqt5-quick</depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/rmf_robot_sim_ignition_plugins/package.xml
+++ b/rmf_robot_sim_ignition_plugins/package.xml
@@ -9,6 +9,7 @@
   <author>Aaron Chong</author>
   <author>Rushyendra Maganty</author>
   <maintainer email="luca@openrobotics.org">Luca Della Vedova</maintainer>
+  <maintainer email="marco@openrobotics.org">Marco A. Gutiérrez</maintainer>
   <license>Apache 2.0</license>
 
   <buildtool_depend>ament_cmake</buildtool_depend>


### PR DESCRIPTION
This PR addresses several dependencies fixes for all the `rmf_simulation` packages at different levels: `CMakeLists.txt`, `package.xml` and `QUALITY_DECLARATION.md`.