### PR TITLE
fix compile error on qt > 5.14

### DIFF
--- a/rmf_building_sim_gazebo_plugins/src/toggle_charging.cpp
+++ b/rmf_building_sim_gazebo_plugins/src/toggle_charging.cpp
@@ -20,7 +20,10 @@
 #include <gazebo/common/Plugin.hh>
 #include <gazebo/gui/GuiPlugin.hh>
 
+#ifndef Q_MOC_RUN
 #include <gazebo/transport/transport.hh>
+#endif
+
 #include <gazebo/msgs/msgs.hh>
 
 #include <rclcpp/rclcpp.hpp>

--- a/rmf_building_sim_gazebo_plugins/src/toggle_floors.cpp
+++ b/rmf_building_sim_gazebo_plugins/src/toggle_floors.cpp
@@ -1,10 +1,13 @@
 #include <functional>
 #include <gazebo/common/Plugin.hh>
 #include <gazebo/gui/GuiPlugin.hh>
+
+#ifndef Q_MOC_RUN
 #include <gazebo/transport/transport.hh>
+#include <gazebo/rendering/rendering.hh>
+#endif
 
 #include <gazebo/msgs/msgs.hh>
-#include <gazebo/rendering/rendering.hh>
 
 #include <rclcpp/rclcpp.hpp>
 #include <gazebo_ros/node.hpp>


### PR DESCRIPTION
<!--
For support requests, please read the Support Guidelines to know where to ask: https://github.com/open-rmf/rmf/wiki/Support-guidelines
For general questions and design discussion, please use the Discussions page: https://github.com/open-rmf/rmf/discussions
Not sure if this is the right repository? Open an issue on https://github.com/open-rmf/rmf
We require contributors to GPG Sign their commits. Follow the guide here to set up a GPG key and add it to your GitHub account: https://docs.github.com/en/github/authenticating-to-github/generating-a-new-gpg-key
A quick guide to how to sign your commits can be seen here: https://gist.github.com/mort3za/ad545d47dd2b54970c102fe39912f305
To GPG sign several commits at once (for example, if you forgot to sign some commits), you can run this command, followed by a force-push: git rebase --exec 'git commit --amend --no-edit -n -S' -i <commit before the first commit you want signed>
For bug fix pull requests, please fill out the information below.
Be as detailed as possible.
-->

## Bug fix

qt > 5.14 had a bug which causes parsing error on intel tbb used by gazebo. A workaround is to wrap certain includes in `#ifndef Q_MOC_RUN`.

Related qt bugs
https://bugreports.qt.io/browse/QTBUG-80990
https://bugreports.qt.io/browse/QTBUG-80578
https://bugreports.qt.io/browse/QTBUG-88125

