### PR TITLE
Build against galactic to make sure that we don't break stuff

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -18,11 +18,11 @@ jobs:
       - name: deps
         uses: ros-tooling/setup-ros@v0.2
         with:
-          required-ros-distributions: foxy
+          required-ros-distributions: ${{ matrix.ros_distribution }}
       - name: build_and_test
         uses: ros-tooling/action-ros-ci@v0.2
         with:
-          target-ros2-distro: foxy
+          target-ros2-distro: ${{ matrix.ros_distribution }}
           # build all packages listed in the meta package
           package-name: |
             rmf_building_sim_common

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -9,6 +9,11 @@ jobs:
   build_and_test:
     name: build_and_test
     runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        ros_distribution:
+          - foxy
+          - galactic
     steps:
       - name: deps
         uses: ros-tooling/setup-ros@v0.2


### PR DESCRIPTION
## Bug fix

### Fixed bug
Galactic has a few API changes that can cause code that builds on foxy to not build on galactic. This PR adds a CI so that we don't commit that type of code.

### Fix applied
Add galactic to CI.
