### PR TITLE
Skip updating ignition plugins when simulation is paused

### DIFF
--- a/rmf_building_sim_ignition_plugins/src/crowd_simulator.cpp
+++ b/rmf_building_sim_ignition_plugins/src/crowd_simulator.cpp
@@ -92,6 +92,10 @@ void CrowdSimulatorPlugin::PreUpdate(
     return;
   }
 
+  // Don't update the plugin if the simulation is paused
+  if (info.paused)
+    return;
+
   // Note, the update_time_step parameter is ignored in ignition
   // through GPU animated actors the performance is good enough that
   // we can afford to update at every iteration and have smooth animations

--- a/rmf_building_sim_ignition_plugins/src/door.cpp
+++ b/rmf_building_sim_ignition_plugins/src/door.cpp
@@ -114,9 +114,9 @@ public:
     if (!_initialized)
       return;
 
-  // Don't update the pose if the simulation is paused
-  if (info.paused)
-    return;
+    // Don't update the pose if the simulation is paused
+    if (info.paused)
+      return;
 
     double t =
       (std::chrono::duration_cast<std::chrono::nanoseconds>(info.simTime).

--- a/rmf_building_sim_ignition_plugins/src/door.cpp
+++ b/rmf_building_sim_ignition_plugins/src/door.cpp
@@ -114,6 +114,10 @@ public:
     if (!_initialized)
       return;
 
+  // Don't update the pose if the simulation is paused
+  if (info.paused)
+    return;
+
     double t =
       (std::chrono::duration_cast<std::chrono::nanoseconds>(info.simTime).
       count()) * 1e-9;

--- a/rmf_building_sim_ignition_plugins/src/lift.cpp
+++ b/rmf_building_sim_ignition_plugins/src/lift.cpp
@@ -255,6 +255,10 @@ public:
     if (!_initialized)
       return;
 
+  // Don't update the pose if the simulation is paused
+  if (info.paused)
+    return;
+
     // Send update request
     const double t =
       (std::chrono::duration_cast<std::chrono::nanoseconds>(info.simTime).

--- a/rmf_building_sim_ignition_plugins/src/lift.cpp
+++ b/rmf_building_sim_ignition_plugins/src/lift.cpp
@@ -255,9 +255,9 @@ public:
     if (!_initialized)
       return;
 
-  // Don't update the pose if the simulation is paused
-  if (info.paused)
-    return;
+    // Don't update the pose if the simulation is paused
+    if (info.paused)
+      return;
 
     // Send update request
     const double t =

--- a/rmf_robot_sim_ignition_plugins/src/TeleportDispenser.cpp
+++ b/rmf_robot_sim_ignition_plugins/src/TeleportDispenser.cpp
@@ -291,6 +291,10 @@ void TeleportDispenserPlugin::PreUpdate(const UpdateInfo& info,
   // TODO parallel thread executor?
   rclcpp::spin_some(_dispenser_common->ros_node);
 
+  // Don't update the pose if the simulation is paused
+  if (info.paused)
+    return;
+
   // Set item that the Dispenser will be configured to dispense. Do this only on first PreUpdate() call.
   // Happens here and not in Configure() to allow for all models to load
   if (!tried_fill_dispenser)

--- a/rmf_robot_sim_ignition_plugins/src/TeleportIngestor.cpp
+++ b/rmf_robot_sim_ignition_plugins/src/TeleportIngestor.cpp
@@ -309,6 +309,10 @@ void TeleportIngestorPlugin::PreUpdate(const UpdateInfo& info,
   // TODO parallel thread executor?
   rclcpp::spin_some(_ingestor_common->ros_node);
 
+  // Don't update the pose if the simulation is paused
+  if (info.paused)
+    return;
+
   std::function<void(void)> send_ingested_item_home_cb =
     std::bind(&TeleportIngestorPlugin::send_ingested_item_home,
       this, std::ref(ecm));

--- a/rmf_robot_sim_ignition_plugins/src/readonly.cpp
+++ b/rmf_robot_sim_ignition_plugins/src/readonly.cpp
@@ -82,6 +82,9 @@ void ReadonlyPlugin::Configure(const Entity& entity,
 void ReadonlyPlugin::PreUpdate(const UpdateInfo& info,
   EntityComponentManager& ecm)
 {
+  // Don't update the pose if the simulation is paused
+  if (info.paused)
+    return;
   auto pose = rmf_plugins_utils::convert_pose(
     ecm.Component<components::Pose>(_en)->Data());
   auto sim_time =

--- a/rmf_robot_sim_ignition_plugins/src/slotcar.cpp
+++ b/rmf_robot_sim_ignition_plugins/src/slotcar.cpp
@@ -334,6 +334,10 @@ void SlotcarPlugin::PreUpdate(const UpdateInfo& info,
   if (_infrastructure.empty())
     init_infrastructure(ecm);
 
+  // Don't update the pose if the simulation is paused
+  if (info.paused)
+    return;
+
   double dt =
     (std::chrono::duration_cast<std::chrono::nanoseconds>(info.dt).count()) *
     1e-9;


### PR DESCRIPTION
## Bug fix

### Fixed bug

Closes [rmf_demos #71](https://github.com/open-rmf/rmf_demos/issues/71).

### Fix applied

Add a check in every plugin and, if the simulation is paused, skip updating.
The crash was caused by the state being updated when simulation is paused, which resulted in a value of `dt` of 0 being used, then divisions by 0 in the velocity calculation resulted in nan values being sent to the physics engine.