### PR TITLE
support reversible slotcar

### DIFF
--- a/rmf_robot_sim_common/include/rmf_robot_sim_common/slotcar_common.hpp
+++ b/rmf_robot_sim_common/include/rmf_robot_sim_common/slotcar_common.hpp
@@ -272,6 +272,8 @@ private:
 
   double _min_turning_radius = -1.0; // minimum turning radius, will use a formula if negative
 
+  bool _reversible = true; // true if the robot can drive backwards
+
   PowerParams _params;
   bool _enable_charge = true;
   bool _enable_instant_charge = false;
@@ -412,6 +414,10 @@ void SlotcarCommon::read_sdf(SdfPtrT& sdf)
   get_element_val_if_present<SdfPtrT, double>(sdf,
     "base_width", this->_base_width);
   RCLCPP_INFO(logger(), "Setting base width to: %f", _base_width);
+
+  get_element_val_if_present<SdfPtrT, bool>(sdf,
+    "reversible", this->_reversible);
+  RCLCPP_INFO(logger(), "Setting reversible to: %d", _reversible);
 
   get_element_val_if_present<SdfPtrT, double>(sdf,
     "nominal_voltage", this->_params.nominal_voltage);

--- a/rmf_robot_sim_common/src/slotcar_common.cpp
+++ b/rmf_robot_sim_common/src/slotcar_common.cpp
@@ -862,9 +862,9 @@ double SlotcarCommon::compute_change_in_rotation(
   }
 
   Eigen::Vector3d target = dpos;
-  // If a traj_vec is provided, of the two possible headings (dpos/-dpos),
-  // choose the one closest to traj_vec
-  if (traj_vec)
+  // If a traj_vec is provided and slotcar is reversible, of the two possible
+  // headings (dpos/-dpos), choose the one closest to traj_vec
+  if (traj_vec && _reversible)
   {
     const double dot = traj_vec->dot(dpos);
     target = dot < 0 ? -dpos : dpos;


### PR DESCRIPTION
Signed-off-by: chianfern <chianfern@gmail.com>

<!--
For support requests, please read the Support Guidelines to know where to ask: https://github.com/open-rmf/rmf/wiki/Support-guidelines
For general questions and design discussion, please use the Discussions page: https://github.com/open-rmf/rmf/discussions
Not sure if this is the right repository? Open an issue on https://github.com/open-rmf/rmf
We require contributors to GPG Sign their commits. Follow the guide here to set up a GPG key and add it to your GitHub account: https://docs.github.com/en/github/authenticating-to-github/generating-a-new-gpg-key
A quick guide to how to sign your commits can be seen here: https://gist.github.com/mort3za/ad545d47dd2b54970c102fe39912f305
To GPG sign several commits at once (for example, if you forgot to sign some commits), you can run this command, followed by a force-push: git rebase --exec 'git commit --amend --no-edit -n -S' -i <commit before the first commit you want signed>
For bug fix pull requests, please fill out the information below.
Be as detailed as possible.
-->

## New feature implementation

### Implemented feature

Closes #35 

### Implementation description

Added _reversible to the slotcar, to be specified in its model.sdf. 
If _reversible is false, don't allow the heading that results in driving in reverse.

However, this appears to cause an issue with the schedule_markers display, especially when a large turn is made.

![gif1](https://user-images.githubusercontent.com/5439856/130216559-adb7b63a-2a40-4e57-ad4a-fd10d1b49c93.gif)
