### PR TITLE
Rename the style check workflow to style

### DIFF
--- a/.github/workflows/style.yaml
+++ b/.github/workflows/style.yaml
@@ -1,7 +1,7 @@
 name: style
 on: [push, pull_request]
 jobs:
-  build:
+  style:
     runs-on: ubuntu-20.04
     container:
       image: docker://ros:foxy-ros-base-focal

--- a/.github/workflows/style.yaml
+++ b/.github/workflows/style.yaml
@@ -15,7 +15,7 @@ jobs:
     - name: rmf_uncrustify
       shell: bash
       run: |
-        wget https://raw.githubusercontent.com/open-rmf/rmf_utils/master/rmf_utils/test/format/rmf_code_style.cfg
+        wget https://raw.githubusercontent.com/open-rmf/rmf_utils/main/rmf_utils/test/format/rmf_code_style.cfg
         source /opt/ros/foxy/setup.bash
         ament_uncrustify -c rmf_code_style.cfg
     - name: pycodestyle


### PR DESCRIPTION
I noticed that the workflow for the style checking is named "build" which is pretty confusing. This PR simply renames it to "style" to make its purpose more clear.