### PR TITLE
Fix velocity control for slotcar in Ignition TPE

### DIFF
--- a/rmf_robot_sim_ignition_plugins/src/slotcar.cpp
+++ b/rmf_robot_sim_ignition_plugins/src/slotcar.cpp
@@ -112,7 +112,8 @@ void SlotcarPlugin::Configure(const Entity& entity,
   //executor->add_node(_ros_node);
   //executor->spin();
   dataPtr->init_ros_node(_ros_node);
-  _canonical_link_entity = ecm.Component<components::ModelCanonicalLink>(_entity)->Data();
+  _canonical_link_entity =
+    ecm.Component<components::ModelCanonicalLink>(_entity)->Data();
 
   // Initialize Pose3d component
   if (!ecm.EntityHasComponentType(entity, components::Pose().TypeId()))


### PR DESCRIPTION
## Bug fix

### Fixed bug

Slotcar in Ignition was relying on an incorrect behavior for velocity control. Specifically it was reading `JointVelocityCmd` to estimate the current robot's velocity, however that component is meant as a write only and the behavior of it being read back to the last command was actually not intended, and it has been fixed with it now always being read as 0.

### Fix applied

Now slotcar reads the velocity from the model's canonical link and uses it for velocity control, unfortunately when using dartsim as a physics engine the robot's friction slows down the robots a lot and they barely move, however this PR fixes behavior under TPE.

To test:
`ros2 launch rmf_demos_ign office.launch.xml use_tpe:=1`

Robots will move after the PR but will be stuck before. Note that doors in TPE don't work since they require [an old PR](https://github.com/open-rmf/rmf_traffic_editor/pull/278) to be picked up again and merged.

Requires [ign-physics #289](https://github.com/ignitionrobotics/ign-physics/pull/289) so it should be tested with a source build of Ignition with the branch above (until it gets merged)