### PR TITLE
Nonholonomic slotcar turning fixes, add turning multiplier offset parameter, rename compute_ds variables

### DIFF
--- a/rmf_robot_sim_common/include/rmf_robot_sim_common/slotcar_common.hpp
+++ b/rmf_robot_sim_common/include/rmf_robot_sim_common/slotcar_common.hpp
@@ -54,11 +54,6 @@ struct NonHolonomicTrajectory
   Eigen::Vector2d v1;
 
   bool turning = false;
-  float turning_radius = 0.0f;
-  float turn_arc_radians = 0.0f;
-  float turn_arclength = 0.0f;
-  Eigen::Vector2d turn_circle_center;
-  Eigen::Vector2d turn_target_heading;
 };
 
 // Edit reference of parameter for template type deduction
@@ -145,7 +140,8 @@ public:
     const std::vector<Eigen::Vector3d>& obstacle_positions,
     const double time);
 
-  std::pair<double, double> update_nonholonomic(Eigen::Isometry3d& pose);
+  std::pair<double, double> update_nonholonomic(Eigen::Isometry3d& pose,
+    const double dt, double& target_linear_velocity);
 
   bool emergency_stop(const std::vector<Eigen::Vector3d>& obstacle_positions,
     const Eigen::Vector3d& current_heading);
@@ -153,7 +149,8 @@ public:
   std::array<double, 2> calculate_control_signals(const std::array<double,
     2>& curr_velocities,
     const std::pair<double, double>& displacements,
-    const double dt) const;
+    const double dt,
+    const double target_linear_velocity = 0.0) const;
 
   std::array<double, 2> calculate_joint_control_signals(
     const std::array<double, 2>& w_tire,
@@ -163,7 +160,8 @@ public:
   std::array<double, 2> calculate_model_control_signals(
     const std::array<double, 2>& curr_velocities,
     const std::pair<double, double>& displacements,
-    const double dt) const;
+    const double dt,
+    const double target_linear_velocity = 0.0) const;
 
   void charge_state_cb(const std::string& name, bool selected);
 
@@ -271,6 +269,7 @@ private:
   double _stop_radius = 1.0;
 
   double _min_turning_radius = -1.0; // minimum turning radius, will use a formula if negative
+  double _computed_turning_multiplier = 1.0; // if _min_turning_radius is computed, this value multiplies it
 
   PowerParams _params;
   bool _enable_charge = true;
@@ -397,6 +396,13 @@ void SlotcarCommon::read_sdf(SdfPtrT& sdf)
     "Setting minimum turning radius to: %f",
     _min_turning_radius);
 
+  get_element_val_if_present<SdfPtrT, double>(sdf,
+    "computed_turning_multiplier", this->_computed_turning_multiplier);
+  RCLCPP_INFO(
+    logger(),
+    "Setting computed turning multiplier to: %f",
+    _computed_turning_multiplier);
+  
   get_element_val_if_present<SdfPtrT, double>(sdf,
     "stop_distance", this->_stop_distance);
   RCLCPP_INFO(logger(), "Setting stop distance to: %f", _stop_distance);

--- a/rmf_robot_sim_common/include/rmf_robot_sim_common/slotcar_common.hpp
+++ b/rmf_robot_sim_common/include/rmf_robot_sim_common/slotcar_common.hpp
@@ -141,7 +141,7 @@ public:
     const double time);
 
   std::pair<double, double> update_nonholonomic(Eigen::Isometry3d& pose,
-    const double dt, double& target_linear_velocity);
+    double& target_linear_velocity);
 
   bool emergency_stop(const std::vector<Eigen::Vector3d>& obstacle_positions,
     const Eigen::Vector3d& current_heading);

--- a/rmf_robot_sim_common/include/rmf_robot_sim_common/slotcar_common.hpp
+++ b/rmf_robot_sim_common/include/rmf_robot_sim_common/slotcar_common.hpp
@@ -402,7 +402,7 @@ void SlotcarCommon::read_sdf(SdfPtrT& sdf)
     logger(),
     "Setting turning right angle multiplier offset to: %f",
     _turning_right_angle_mul_offset);
-  
+
   get_element_val_if_present<SdfPtrT, double>(sdf,
     "stop_distance", this->_stop_distance);
   RCLCPP_INFO(logger(), "Setting stop distance to: %f", _stop_distance);

--- a/rmf_robot_sim_common/include/rmf_robot_sim_common/slotcar_common.hpp
+++ b/rmf_robot_sim_common/include/rmf_robot_sim_common/slotcar_common.hpp
@@ -152,17 +152,17 @@ public:
 
   std::array<double, 2> calculate_control_signals(const std::array<double,
     2>& curr_velocities,
-    const std::pair<double, double>& velocities,
+    const std::pair<double, double>& displacements,
     const double dt) const;
 
   std::array<double, 2> calculate_joint_control_signals(
     const std::array<double, 2>& w_tire,
-    const std::pair<double, double>& velocities,
+    const std::pair<double, double>& displacements,
     const double dt) const;
 
   std::array<double, 2> calculate_model_control_signals(
     const std::array<double, 2>& curr_velocities,
-    const std::pair<double, double>& velocities,
+    const std::pair<double, double>& displacements,
     const double dt) const;
 
   void charge_state_cb(const std::string& name, bool selected);

--- a/rmf_robot_sim_common/include/rmf_robot_sim_common/slotcar_common.hpp
+++ b/rmf_robot_sim_common/include/rmf_robot_sim_common/slotcar_common.hpp
@@ -269,7 +269,7 @@ private:
   double _stop_radius = 1.0;
 
   double _min_turning_radius = -1.0; // minimum turning radius, will use a formula if negative
-  double _computed_turning_multiplier = 1.0; // if _min_turning_radius is computed, this value multiplies it
+  double _turning_right_angle_mul_offset = 1.0; // if _min_turning_radius is computed, this value multiplies it
 
   PowerParams _params;
   bool _enable_charge = true;
@@ -397,11 +397,11 @@ void SlotcarCommon::read_sdf(SdfPtrT& sdf)
     _min_turning_radius);
 
   get_element_val_if_present<SdfPtrT, double>(sdf,
-    "computed_turning_multiplier", this->_computed_turning_multiplier);
+    "turning_right_angle_mul_offset", this->_turning_right_angle_mul_offset);
   RCLCPP_INFO(
     logger(),
-    "Setting computed turning multiplier to: %f",
-    _computed_turning_multiplier);
+    "Setting turning right angle multiplier offset to: %f",
+    _turning_right_angle_mul_offset);
   
   get_element_val_if_present<SdfPtrT, double>(sdf,
     "stop_distance", this->_stop_distance);

--- a/rmf_robot_sim_common/include/rmf_robot_sim_common/utils.hpp
+++ b/rmf_robot_sim_common/include/rmf_robot_sim_common/utils.hpp
@@ -60,7 +60,8 @@ double compute_ds(
   const double v_max,
   const double accel_nom,
   const double accel_max,
-  const double dt);
+  const double dt,
+  const double v_target = 0.0);
 
 struct MotionParams
 {

--- a/rmf_robot_sim_common/src/slotcar_common.cpp
+++ b/rmf_robot_sim_common/src/slotcar_common.cpp
@@ -320,7 +320,7 @@ void SlotcarCommon::ackmann_path_request_cb(
     double m = diff / range;
     m = m > 1.0 ? 1.0 : m;
     m = m < 0.0 ? 0.0 : m;
-    double multiplier = 1.0 + (1.0 - m) * 0.5;
+    double multiplier = 1.0 + (1.0 - m) * _turning_right_angle_mul_offset;
     double target_radius = min_turning_radius * multiplier;
 
     // use sin rule to obtain length of tangent
@@ -364,11 +364,6 @@ void SlotcarCommon::ackmann_path_request_cb(
         true);
       turn_traj.v0 = -wp1_to_wp0_norm;
       turn_traj.v1 = wp1_to_wp2_norm;
-
-      Eigen::Vector2d wp0_to_wp1_norm = -wp1_to_wp0_norm;
-      Eigen::Vector2d perp_wp1_wp2(wp0_to_wp1_norm.y(), -wp0_to_wp1_norm.x());
-      if (cp < 0)
-        perp_wp1_wp2 = -perp_wp1_wp2;
 
       NonHolonomicTrajectory end_traj(
         Eigen::Vector2d(tangent1.x(), tangent1.y()),

--- a/rmf_robot_sim_common/src/slotcar_common.cpp
+++ b/rmf_robot_sim_common/src/slotcar_common.cpp
@@ -419,7 +419,8 @@ std::array<double, 2> SlotcarCommon::calculate_model_control_signals(
   const double dt,
   const double target_linear_velocity) const
 {
-  return calculate_control_signals(curr_velocities, displacements, dt, target_linear_velocity);
+  return calculate_control_signals(curr_velocities, displacements, dt,
+      target_linear_velocity);
 }
 
 std::array<double, 2> SlotcarCommon::calculate_joint_control_signals(
@@ -745,8 +746,10 @@ std::pair<double, double> SlotcarCommon::update_nonholonomic(
     Eigen::Vector2d target_heading = traj.v1;
 
     double heading_dotp = heading.dot(target_heading);
-    double cross = heading.x() * target_heading.y() - heading.y() * target_heading.x();
-    displacements.second = cross < 0.0 ? -acos(heading_dotp) : acos(heading_dotp);
+    double cross = heading.x() * target_heading.y() - heading.y() *
+      target_heading.x();
+    displacements.second = cross <
+      0.0 ? -acos(heading_dotp) : acos(heading_dotp);
 
     // figure out if we're close enough
     Eigen::Vector2d dest_pt = traj.x1;

--- a/rmf_robot_sim_common/src/utils.cpp
+++ b/rmf_robot_sim_common/src/utils.cpp
@@ -49,11 +49,11 @@ double compute_ds(
     }
   }
 
-  // if you have a target velocity and a distance shorter than that, set to 
+  // if you have a target velocity and a distance shorter than that, set to
   // the target velocity otherwise it'll hard-stop
   if (s_target < v_target)
     next_v = v_target;
-  
+
   // Flip the sign the to correct direction before returning the value
   return sign * next_v;
 }

--- a/rmf_robot_sim_common/src/utils.cpp
+++ b/rmf_robot_sim_common/src/utils.cpp
@@ -12,7 +12,8 @@ double compute_ds(
   const double v_max,
   const double accel_nom,
   const double accel_max,
-  const double dt)
+  const double dt,
+  const double v_target)
 {
   double sign = 1.0;
   if (s_target < 0.0)
@@ -25,31 +26,36 @@ double compute_ds(
   }
 
   // We should try not to shoot past the targstd::vector<event::ConnectionPtr> connections;et
-  double next_s = s_target / dt;
+  double next_v = s_target / dt;
 
   // Test velocity limit
-  next_s = std::min(next_s, v_max);
+  next_v = std::min(next_v, v_max);
 
   // Test acceleration limit
-  next_s = std::min(next_s, accel_nom * dt + v_actual);
+  next_v = std::min(next_v, accel_nom * dt + v_actual);
 
   if (v_actual > 0.0 && s_target > 0.0)
   {
     // This is what our deceleration should be if we want to begin a constant
     // deceleration from now until we reach the goal
-    double deceleration = pow(v_actual, 2) / s_target;
+    double deceleration = pow(v_actual - v_target, 2) / s_target;
     deceleration = std::min(deceleration, accel_max);
 
     if (accel_nom <= deceleration)
     {
       // If the smallest constant deceleration for reaching the goal is
       // greater than
-      next_s = -deceleration * dt + v_actual;
+      next_v = -deceleration * dt + v_actual;
     }
   }
 
+  // if you have a target velocity and a distance shorter than that, set to 
+  // the target velocity otherwise it'll hard-stop
+  if (s_target < v_target)
+    next_v = v_target;
+  
   // Flip the sign the to correct direction before returning the value
-  return sign * next_s;
+  return sign * next_v;
 }
 
 //==============================================================================

--- a/rmf_robot_sim_gazebo_plugins/src/slotcar.cpp
+++ b/rmf_robot_sim_gazebo_plugins/src/slotcar.cpp
@@ -42,14 +42,14 @@ private:
 
   void charge_state_cb(ConstSelectionPtr& msg);
 
-  void send_control_signals(const std::pair<double, double>& velocities,
+  void send_control_signals(const std::pair<double, double>& displacements,
     const double dt)
   {
     std::array<double, 2> w_tire;
     for (std::size_t i = 0; i < 2; ++i)
       w_tire[i] = joints[i]->GetVelocity(0);
     auto joint_signals = dataPtr->calculate_joint_control_signals(w_tire,
-        velocities, dt);
+        displacements, dt);
     for (std::size_t i = 0; i < 2; ++i)
     {
       joints[i]->SetParam("vel", 0, joint_signals[i]);
@@ -164,11 +164,11 @@ void SlotcarPlugin::OnUpdate()
   auto pose = _model->WorldPose();
   auto obstacle_positions = get_obstacle_positions(world);
 
-  auto velocities =
+  auto displacements =
     dataPtr->update(rmf_plugins_utils::convert_pose(pose),
       obstacle_positions, time);
 
-  send_control_signals(velocities, dt);
+  send_control_signals(displacements, dt);
 }
 
 GZ_REGISTER_MODEL_PLUGIN(SlotcarPlugin)

--- a/rmf_robot_sim_ignition_plugins/src/slotcar.cpp
+++ b/rmf_robot_sim_ignition_plugins/src/slotcar.cpp
@@ -357,7 +357,7 @@ void SlotcarPlugin::PreUpdate(const UpdateInfo& info,
     double target_linear_velocity = 0.0;
     auto& pose = ecm.Component<components::Pose>(_entity)->Data();
     auto isometry_pose = rmf_plugins_utils::convert_pose(pose);
-    auto displacements = dataPtr->update_nonholonomic(isometry_pose, dt, target_linear_velocity);
+    auto displacements = dataPtr->update_nonholonomic(isometry_pose, target_linear_velocity);
 
     //convert back to account for flips
     pose = rmf_plugins_utils::convert_to_pose<ignition::math::Pose3d>(

--- a/rmf_robot_sim_ignition_plugins/src/slotcar.cpp
+++ b/rmf_robot_sim_ignition_plugins/src/slotcar.cpp
@@ -63,7 +63,7 @@ private:
   void charge_state_cb(const ignition::msgs::Selection& msg);
 
   void send_control_signals(EntityComponentManager& ecm,
-    const std::pair<double, double>& velocities,
+    const std::pair<double, double>& displacements,
     const std::unordered_set<Entity> payloads,
     const double dt);
   void init_infrastructure(EntityComponentManager& ecm);
@@ -152,7 +152,7 @@ void SlotcarPlugin::Configure(const Entity& entity,
 }
 
 void SlotcarPlugin::send_control_signals(EntityComponentManager& ecm,
-  const std::pair<double, double>& velocities,
+  const std::pair<double, double>& displacements,
   const std::unordered_set<Entity> payloads,
   const double dt)
 {
@@ -165,7 +165,7 @@ void SlotcarPlugin::send_control_signals(EntityComponentManager& ecm,
   double w_robot = ang_vel_cmd->Data()[2];
   std::array<double, 2> target_vels;
   target_vels = dataPtr->calculate_model_control_signals({v_robot, w_robot},
-      velocities, dt);
+      displacements, dt);
 
   lin_vel_cmd->Data()[0] = target_vels[0];
   ang_vel_cmd->Data()[2] = target_vels[1];
@@ -354,13 +354,13 @@ void SlotcarPlugin::PreUpdate(const UpdateInfo& info,
   {
     auto& pose = ecm.Component<components::Pose>(_entity)->Data();
     auto isometry_pose = rmf_plugins_utils::convert_pose(pose);
-    auto velocities = dataPtr->update_nonholonomic(isometry_pose);
+    auto displacements = dataPtr->update_nonholonomic(isometry_pose);
 
     //convert back to account for flips
     pose = rmf_plugins_utils::convert_to_pose<ignition::math::Pose3d>(
       isometry_pose);
 
-    send_control_signals(ecm, velocities, _payloads, dt);
+    send_control_signals(ecm, displacements, _payloads, dt);
   }
   else
   {
@@ -371,11 +371,11 @@ void SlotcarPlugin::PreUpdate(const UpdateInfo& info,
 
     //printf("%s: %g %g!\n", dataPtr->model_name().c_str(), p.X(), p.Y());
 
-    auto velocities =
+    auto displacements =
       dataPtr->update(rmf_plugins_utils::convert_pose(pose),
         obstacle_positions, time);
 
-    send_control_signals(ecm, velocities, _payloads, dt);
+    send_control_signals(ecm, displacements, _payloads, dt);
   }
 }
 

--- a/rmf_robot_sim_ignition_plugins/src/slotcar.cpp
+++ b/rmf_robot_sim_ignition_plugins/src/slotcar.cpp
@@ -357,13 +357,15 @@ void SlotcarPlugin::PreUpdate(const UpdateInfo& info,
     double target_linear_velocity = 0.0;
     auto& pose = ecm.Component<components::Pose>(_entity)->Data();
     auto isometry_pose = rmf_plugins_utils::convert_pose(pose);
-    auto displacements = dataPtr->update_nonholonomic(isometry_pose, target_linear_velocity);
+    auto displacements = dataPtr->update_nonholonomic(isometry_pose,
+        target_linear_velocity);
 
     //convert back to account for flips
     pose = rmf_plugins_utils::convert_to_pose<ignition::math::Pose3d>(
       isometry_pose);
 
-    send_control_signals(ecm, displacements, _payloads, dt, target_linear_velocity);
+    send_control_signals(ecm, displacements, _payloads, dt,
+      target_linear_velocity);
   }
   else
   {


### PR DESCRIPTION
## Bug fix

### Fixed bugs

- The nonholonomic slotcar plugin had a problem with it's turning due to the computation of the turn delta, this PR fixes it via using the arcosine of the dot product.

- Another problem is the decceleration applied to velocities in `compute_ds`, making our slotcar enter turns from `0` velocity and in turn making the turn look weird. To fix this we added `target_velocity` as a targeted final velocity as `target_s` reaches `0`.

- Added  `_turning_right_angle_mul_offset` as an added multiplier applied to the turning radius for right-angled turns within 20 degrees. Eg. A value of `0.5` for `_turning_right_angle_mul_offset` makes for a multiplier `1.5` when is applied to a `90 degree` turning radius, and linearly downscales to `1.0` for a `70 degree` turning radius. This compensates for turning acc/deccelerations making turns 'overshoot'.

- Corrects up some variables named `velocities` when they were in fact `displacements`.

- Removes unneeded variables in various spots

In conjunction with https://github.com/open-rmf/rmf_demos/pull/82

