### PR TITLE
Clamp acos argument to avoid nan results

### DIFF
--- a/rmf_robot_sim_common/src/slotcar_common.cpp
+++ b/rmf_robot_sim_common/src/slotcar_common.cpp
@@ -721,6 +721,8 @@ SlotcarCommon::UpdateResult SlotcarCommon::update_ackermann(
 
       double dotp = heading.dot(dpos_norm);
       double cross = heading.x() * dpos_norm.y() - heading.y() * dpos_norm.x();
+      // Clamp to avoid numerical errors due to floating point precision
+      std::clamp(dotp, -1.0, 1.0);
       result.w = cross < 0.0 ? -acos(dotp) : acos(dotp);
     }
     else
@@ -742,6 +744,8 @@ SlotcarCommon::UpdateResult SlotcarCommon::update_ackermann(
     double heading_dotp = heading.dot(target_heading);
     double cross = heading.x() * target_heading.y() - heading.y() *
       target_heading.x();
+    // Clamp to avoid numerical errors due to floating point precision
+    std::clamp(heading_dotp, -1.0, 1.0);
     result.w = cross <
       0.0 ? -acos(heading_dotp) : acos(heading_dotp);
 


### PR DESCRIPTION
## Bug fix

### Fixed bug

Since `acos` is only defined in the [-1.1] interval, any value outside of the interval results in return values of `nan` that, in turn, cause the physics solver and ignition to crash.
Due to floating point rounding errors it is _possible_ that the value will be slightly above 1.0, for example when adding to [this](https://github.com/open-rmf/rmf_simulation/blob/main/rmf_robot_sim_common/src/slotcar_common.cpp#L724) line the following print statements:
```
   1       std::cout << "Result pre-acos " << result.w << std::endl;
   2       std::cout << "Calculating acos of " << dotp << std::endl;
   3       result.w = cross < 0.0 ? -acos(dotp) : acos(dotp);
   4       std::cout << "Result post-acos " << result.w << std::endl;
```
The resulting output can be the following:
```
[ign-5] Result pre-acos 0
[ign-5] Calculating acos of 1
[ign-5] Result post-acos -nan
```

### Fix applied

This PR clamps the acos argument of the ackermann steering update function to the [-1,1] interval