### PR TITLE
Use return value of std::clamp

### DIFF
--- a/rmf_robot_sim_common/src/slotcar_common.cpp
+++ b/rmf_robot_sim_common/src/slotcar_common.cpp
@@ -722,7 +722,7 @@ SlotcarCommon::UpdateResult SlotcarCommon::update_ackermann(
       double dotp = heading.dot(dpos_norm);
       double cross = heading.x() * dpos_norm.y() - heading.y() * dpos_norm.x();
       // Clamp to avoid numerical errors due to floating point precision
-      std::clamp(dotp, -1.0, 1.0);
+      dotp = std::clamp(dotp, -1.0, 1.0);
       result.w = cross < 0.0 ? -acos(dotp) : acos(dotp);
     }
     else
@@ -745,7 +745,7 @@ SlotcarCommon::UpdateResult SlotcarCommon::update_ackermann(
     double cross = heading.x() * target_heading.y() - heading.y() *
       target_heading.x();
     // Clamp to avoid numerical errors due to floating point precision
-    std::clamp(heading_dotp, -1.0, 1.0);
+    heading_dotp = std::clamp(heading_dotp, -1.0, 1.0);
     result.w = cross <
       0.0 ? -acos(heading_dotp) : acos(heading_dotp);
 


### PR DESCRIPTION
## Bug fix

### Fixed bug

Followup of #50, the PR incorrectly assumed that `std::clamp` modified the input argument and thus ignored the return value, making the fix actually do nothing.
It probably wasn't noticed because the crash itself is somewhat hard to reproduce due to the nature of the bug. 

### Fix applied

This fix actually uses the return value of `std::clamp` making the clamping work in avoiding `nan` errors when using acos with floating point errors.