### PR TITLE
Change default lift current mode to AGV

### DIFF
--- a/rmf_building_sim_common/src/lift_common.cpp
+++ b/rmf_building_sim_common/src/lift_common.cpp
@@ -256,6 +256,7 @@ LiftCommon::LiftCommon(rclcpp::Node::SharedPtr node,
   _lift_state.destination_floor = initial_floor_name;
   _lift_state.door_state = LiftState::DOOR_CLOSED;
   _lift_state.motion_state = LiftState::MOTION_STOPPED;
+  _lift_state.current_mode = LiftState::MODE_AGV;
   for (const std::string& floor_name : _floor_names)
     _lift_state.available_floors.push_back(floor_name);
 }


### PR DESCRIPTION
Signed-off-by: Charayaphan Nakorn Boon Han <charayaphan.nakorn.boon.han@gmail.com>

## Bug fix

### Fixed bug

https://github.com/open-rmf/rmf_simulation/blob/main/rmf_building_sim_common/src/lift_common.cpp#L271
https://github.com/open-rmf/rmf_simulation/blob/main/rmf_building_sim_common/src/lift_common.cpp#L254-L258
Currently, the plugin defaults to publishing MODE_UNKNOWN as the initial current_mode. This causes issues downstream in rmf-web https://github.com/open-rmf/rmf-web/issues/510

### Fix applied

Enforce initial state of lift to be AGV mode for gazebo simulations

