### PR TITLE
add markers, ackermann steering vehicles now use seperate motion function and final target yaw

### DIFF
--- a/rmf_robot_sim_common/include/rmf_robot_sim_common/slotcar_common.hpp
+++ b/rmf_robot_sim_common/include/rmf_robot_sim_common/slotcar_common.hpp
@@ -275,6 +275,7 @@ private:
   double _turning_right_angle_mul_offset = 1.0; // if _min_turning_radius is computed, this value multiplies it
 
   bool _reversible = true; // true if the robot can drive backwards
+  bool _obey_target_yaw_ackermann = false;
 
   PowerParams _params;
   bool _enable_charge = true;
@@ -441,6 +442,11 @@ void SlotcarCommon::read_sdf(SdfPtrT& sdf)
   get_element_val_if_present<SdfPtrT, double>(sdf,
     "base_width", this->_base_width);
   RCLCPP_INFO(logger(), "Setting base width to: %f", _base_width);
+
+  get_element_val_if_present<SdfPtrT, bool>(sdf,
+    "obey_target_yaw_ackermann", this->_obey_target_yaw_ackermann);
+  RCLCPP_INFO(logger(), "Setting _obey_target_yaw_ackermann to: %d",
+    _obey_target_yaw_ackermann);
 
   get_element_val_if_present<SdfPtrT, bool>(sdf,
     "reversible", this->_reversible);

--- a/rmf_robot_sim_common/include/rmf_robot_sim_common/slotcar_common.hpp
+++ b/rmf_robot_sim_common/include/rmf_robot_sim_common/slotcar_common.hpp
@@ -172,6 +172,11 @@ public:
 
   void publish_robot_state(const double time);
 
+  using PathRequestCallback =
+    std::function<void(const rmf_fleet_msgs::msg::PathRequest::SharedPtr)>;
+  void set_path_request_callback(PathRequestCallback cb)
+  { _path_request_callback = cb; }
+
 private:
   // Paramters needed for power dissipation and charging calculations
   // Default values may be overriden using values from sdf file
@@ -293,6 +298,8 @@ private:
   static constexpr double _charger_dist_thres = 0.3;
 
   bool _docking = false;
+
+  PathRequestCallback _path_request_callback = nullptr;
 
   std::string get_level_name(const double z) const;
 

--- a/rmf_robot_sim_common/include/rmf_robot_sim_common/utils.hpp
+++ b/rmf_robot_sim_common/include/rmf_robot_sim_common/utils.hpp
@@ -63,6 +63,15 @@ double compute_ds(
   const double dt,
   const double v_target = 0.0);
 
+double compute_ds_linear(
+  double s_target,
+  double v_actual,
+  const double v_max,
+  const double accel_nom,
+  const double accel_max,
+  const double dt,
+  const double v_target = 0.0);
+
 struct MotionParams
 {
   double v_max = 0.2;

--- a/rmf_robot_sim_common/src/slotcar_common.cpp
+++ b/rmf_robot_sim_common/src/slotcar_common.cpp
@@ -272,6 +272,10 @@ void SlotcarCommon::handle_ackermann_path_request(
   if (locations.size() < 2)
     return;
 
+
+  if (_path_request_callback)
+    _path_request_callback(msg);
+
   // add 1st trajectory
   AckermannTrajectory traj(
     Eigen::Vector2d(locations[0].x, locations[0].y),

--- a/rmf_robot_sim_common/src/slotcar_common.cpp
+++ b/rmf_robot_sim_common/src/slotcar_common.cpp
@@ -399,11 +399,19 @@ std::array<double, 2> SlotcarCommon::calculate_control_signals(
   const double v_robot = curr_velocities[0];
   const double w_robot = curr_velocities[1];
 
-  const double v_target = rmf_plugins_utils::compute_ds(displacements.first,
-      v_robot,
-      _nominal_drive_speed,
-      _nominal_drive_acceleration, _max_drive_acceleration, dt,
-      target_linear_velocity);
+  double v_target = 0.0;
+  if (this->_steering_type == SteeringType::ACKERMANN)
+    v_target = rmf_plugins_utils::compute_ds_linear(displacements.first,
+        v_robot,
+        _nominal_drive_speed,
+        _nominal_drive_acceleration, _max_drive_acceleration, dt,
+        target_linear_velocity);
+  else
+    v_target = rmf_plugins_utils::compute_ds(displacements.first,
+        v_robot,
+        _nominal_drive_speed,
+        _nominal_drive_acceleration, _max_drive_acceleration, dt,
+        target_linear_velocity);
 
   double w_target = rmf_plugins_utils::compute_ds(displacements.second,
       w_robot,

--- a/rmf_robot_sim_common/src/slotcar_common.cpp
+++ b/rmf_robot_sim_common/src/slotcar_common.cpp
@@ -378,7 +378,7 @@ void SlotcarCommon::handle_ackermann_path_request(
 
   AckermannTrajectory& last_traj = this->ackermann_trajectory.back();
   last_traj.v1 = last_traj.v0;
-  
+
   if (_obey_target_yaw_ackermann)
   {
     // add a turning trajectory to the desired yaw if it differs from the computed one
@@ -424,10 +424,10 @@ void SlotcarCommon::handle_ackermann_path_request(
         tangent_pt = p2 - side_perp;
 
       AckermannTrajectory end_turn_traj(
-          Eigen::Vector2d(tangent_pt.x(), tangent_pt.y()),
-          Eigen::Vector2d(last_traj.x1.x(), last_traj.x1.y()),
-          Eigen::Vector2d(0, 0),
-          true);
+        Eigen::Vector2d(tangent_pt.x(), tangent_pt.y()),
+        Eigen::Vector2d(last_traj.x1.x(), last_traj.x1.y()),
+        Eigen::Vector2d(0, 0),
+        true);
       last_traj.x1 = tangent_pt;
       last_traj.v1 = last_traj.v0;
       end_turn_traj.v0 = last_traj.v1;
@@ -799,10 +799,10 @@ SlotcarCommon::UpdateResult SlotcarCommon::update_ackermann(
       result.speed = _nominal_drive_speed;
     else
     {
-      // last segment, starting from 0 velocity to 
+      // last segment, starting from 0 velocity to
       auto& last_segment = ackermann_trajectory[_ackermann_traj_idx];
       double segment_dist = (last_segment.x1 - last_segment.x0).norm();
-      
+
       if (dpos_mag >= (segment_dist * 0.5))
       {
         // if we're in the first half of the segment,
@@ -846,14 +846,15 @@ SlotcarCommon::UpdateResult SlotcarCommon::update_ackermann(
     // determine turn directionality
     Eigen::Vector2d traj_start_to_dest_pt = dest_pt - traj.x0;
     Eigen::Vector2d start_heading = traj.v0;
-    double cross = start_heading.x() * traj_start_to_dest_pt.y() - start_heading.y() *
+    double cross = start_heading.x() * traj_start_to_dest_pt.y() -
+      start_heading.y() *
       traj_start_to_dest_pt.x();
 
     if (heading_dotp > 0.99 && projection < -0.75)
       result.w = 0.0;
     else
       result.w = cross < 0.0 ? -acos(heading_dotp) : acos(heading_dotp);
-    
+
     close_enough = heading_dotp > 0.99 && projection > 0.0;
   }
 

--- a/rmf_robot_sim_common/src/slotcar_common.cpp
+++ b/rmf_robot_sim_common/src/slotcar_common.cpp
@@ -379,59 +379,62 @@ void SlotcarCommon::handle_ackermann_path_request(
   AckermannTrajectory& last_traj = this->ackermann_trajectory.back();
   last_traj.v1 = last_traj.v0;
   
-  // add a turning trajectory to the desired yaw if it differs from the computed one
-  double prev_yaw = atan2(last_traj.v1.y(), last_traj.v1.x());
-  auto& last_location = locations.back();
-  double desired_yaw = last_location.yaw;
-  double threshold = 5.0 / 180.0 * M_PI;
-  if (std::abs(desired_yaw - prev_yaw) >= threshold)
+  if (_obey_target_yaw_ackermann)
   {
-    double radius = min_turning_radius * 0.5;
+    // add a turning trajectory to the desired yaw if it differs from the computed one
+    double prev_yaw = atan2(last_traj.v1.y(), last_traj.v1.x());
+    auto& last_location = locations.back();
+    double desired_yaw = last_location.yaw;
+    double threshold = 5.0 / 180.0 * M_PI;
+    if (std::abs(desired_yaw - prev_yaw) >= threshold)
+    {
+      double radius = min_turning_radius * 0.5;
 
-    bool turn_left = prev_yaw < desired_yaw;
-    Eigen::Vector2d circle_position;
-    Eigen::Vector2d tangent_to_circle;
+      bool turn_left = prev_yaw < desired_yaw;
+      Eigen::Vector2d circle_position;
+      Eigen::Vector2d tangent_to_circle;
 
-    Eigen::Vector2d v = Eigen::Vector2d(cos(desired_yaw), sin(desired_yaw));
-    Eigen::Vector2d v_perp = Eigen::Vector2d(v.y(), -v.x());
+      Eigen::Vector2d v = Eigen::Vector2d(cos(desired_yaw), sin(desired_yaw));
+      Eigen::Vector2d v_perp = Eigen::Vector2d(v.y(), -v.x());
 
-    if (turn_left)
-      circle_position = last_traj.x1 - v_perp * radius;
-    else // turn right
-      circle_position = last_traj.x1 + v_perp * radius;
+      if (turn_left)
+        circle_position = last_traj.x1 - v_perp * radius;
+      else // turn right
+        circle_position = last_traj.x1 + v_perp * radius;
 
-    // solve for tangent point
-    // https://web.archive.org/web/20210124122457/http://csharphelper.com/blog/2014/09/determine-where-two-circles-intersect-in-c/
-    Eigen::Vector2d p0 = last_traj.x0;
-    Eigen::Vector2d p1 = circle_position;
-    Eigen::Vector2d p0_to_p1 = p1 - p0;
-    double d = p0_to_p1.norm();
-    double r1 = radius;
-    double r0 = sqrt(d * d - r1 * r1);
-    double a = (r0 * r0 - r1 * r1 + d * d) / (2.0 * d);
-    double h = sqrt(r0 * r0 - a * a);
+      // solve for tangent point
+      // https://web.archive.org/web/20210124122457/http://csharphelper.com/blog/2014/09/determine-where-two-circles-intersect-in-c/
+      Eigen::Vector2d p0 = last_traj.x0;
+      Eigen::Vector2d p1 = circle_position;
+      Eigen::Vector2d p0_to_p1 = p1 - p0;
+      double d = p0_to_p1.norm();
+      double r1 = radius;
+      double r0 = sqrt(d * d - r1 * r1);
+      double a = (r0 * r0 - r1 * r1 + d * d) / (2.0 * d);
+      double h = sqrt(r0 * r0 - a * a);
 
-    Eigen::Vector2d p2 = p0 + (p0_to_p1 / d) * a;
-    Eigen::Vector2d side = (p0_to_p1 / d) * h;
-    Eigen::Vector2d side_perp = Eigen::Vector2d(side.y(), -side.x());
+      Eigen::Vector2d p2 = p0 + (p0_to_p1 / d) * a;
+      Eigen::Vector2d side = (p0_to_p1 / d) * h;
+      Eigen::Vector2d side_perp = Eigen::Vector2d(side.y(), -side.x());
 
-    Eigen::Vector2d tangent_pt;
-    if (turn_left)
-      tangent_pt = p2 + side_perp;
-    else
-      tangent_pt = p2 - side_perp;
+      Eigen::Vector2d tangent_pt;
+      if (turn_left)
+        tangent_pt = p2 + side_perp;
+      else
+        tangent_pt = p2 - side_perp;
 
-    AckermannTrajectory end_turn_traj(
-        Eigen::Vector2d(tangent_pt.x(), tangent_pt.y()),
-        Eigen::Vector2d(last_traj.x1.x(), last_traj.x1.y()),
-        Eigen::Vector2d(0, 0),
-        true);
-    last_traj.x1 = tangent_pt;
-    last_traj.v1 = last_traj.v0;
-    end_turn_traj.v0 = last_traj.v1;
-    end_turn_traj.v1 = v;
+      AckermannTrajectory end_turn_traj(
+          Eigen::Vector2d(tangent_pt.x(), tangent_pt.y()),
+          Eigen::Vector2d(last_traj.x1.x(), last_traj.x1.y()),
+          Eigen::Vector2d(0, 0),
+          true);
+      last_traj.x1 = tangent_pt;
+      last_traj.v1 = last_traj.v0;
+      end_turn_traj.v0 = last_traj.v1;
+      end_turn_traj.v1 = v;
 
-    this->ackermann_trajectory.push_back(end_turn_traj);
+      this->ackermann_trajectory.push_back(end_turn_traj);
+    }
   }
 }
 

--- a/rmf_robot_sim_common/src/slotcar_common.cpp
+++ b/rmf_robot_sim_common/src/slotcar_common.cpp
@@ -394,7 +394,7 @@ void SlotcarCommon::handle_ackermann_path_request(
 
     Eigen::Vector2d v = Eigen::Vector2d(cos(desired_yaw), sin(desired_yaw));
     Eigen::Vector2d v_perp = Eigen::Vector2d(v.y(), -v.x());
-    std::cout << v_perp << std::endl;
+
     if (turn_left)
       circle_position = last_traj.x1 - v_perp * radius;
     else // turn right

--- a/rmf_robot_sim_common/src/utils.cpp
+++ b/rmf_robot_sim_common/src/utils.cpp
@@ -59,6 +59,54 @@ double compute_ds(
 }
 
 //==============================================================================
+double compute_ds_linear(
+  double s_target,
+  double v_actual,
+  const double v_max,
+  const double accel_nom,
+  const double accel_max,
+  const double dt,
+  const double v_target)
+{
+  double sign = 1.0;
+  if (s_target < 0.0)
+  {
+    // Limits get confusing when we need to go backwards, so we'll flip signs
+    // here so that we pretend the target is forwards
+    s_target *= -1.0;
+    v_actual *= -1.0;
+    sign = -1.0;
+  }
+
+  // We should try not to shoot past the targstd::vector<event::ConnectionPtr> connections;et
+  double next_v = s_target / dt;
+
+  // Test velocity limit
+  next_v = std::min(next_v, v_max);
+
+  // Test acceleration limit
+  next_v = std::min(next_v, accel_nom * dt + v_actual);
+
+  if (v_actual > 0.0 && s_target > 0.0)
+  {
+    // use equations of motion to figure out an acceleration
+    double desired_acceleration = (pow(v_target, 2) - pow(v_actual, 2)) / (2.0 * s_target);
+    if (desired_acceleration > accel_max)
+      desired_acceleration = accel_max;
+
+    next_v = desired_acceleration * dt + v_actual;
+  }
+
+  // if you have a target velocity and a distance shorter than that, set to
+  // the target velocity otherwise it'll hard-stop
+  if (s_target < v_target)
+    next_v = v_target;
+
+  // Flip the sign the to correct direction before returning the value
+  return sign * next_v;
+}
+
+//==============================================================================
 double compute_desired_rate_of_change(
   double _s_target,
   double _v_actual,

--- a/rmf_robot_sim_common/src/utils.cpp
+++ b/rmf_robot_sim_common/src/utils.cpp
@@ -90,7 +90,8 @@ double compute_ds_linear(
   if (v_actual > 0.0 && s_target > 0.0)
   {
     // use equations of motion to figure out an acceleration
-    double desired_acceleration = (pow(v_target, 2) - pow(v_actual, 2)) / (2.0 * s_target);
+    double desired_acceleration =
+      (pow(v_target, 2) - pow(v_actual, 2)) / (2.0 * s_target);
     if (desired_acceleration > accel_max)
       desired_acceleration = accel_max;
 

--- a/rmf_robot_sim_ignition_plugins/src/slotcar.cpp
+++ b/rmf_robot_sim_ignition_plugins/src/slotcar.cpp
@@ -386,8 +386,18 @@ void SlotcarPlugin::path_request_marker_update(
   const rmf_fleet_msgs::msg::PathRequest::SharedPtr msg)
 {
   auto& locations = msg->path;
-  _trajectory_marker_msg.clear_marker();
 
+  ignition::msgs::Boolean res;
+  bool result;
+  for (uint i = 0; i < _trajectory_marker_msg.marker_size(); ++i)
+  {
+    auto marker = _trajectory_marker_msg.mutable_marker(i);
+    marker->set_action(ignition::msgs::Marker::DELETE_ALL);
+  }
+  _trajectory_marker_node.Request(
+    "/marker_array", _trajectory_marker_msg, 5000, res, result);
+
+  _trajectory_marker_msg.clear_marker();
   double elevation = 0.05;
 
   auto marker = _trajectory_marker_msg.add_marker();
@@ -396,7 +406,7 @@ void SlotcarPlugin::path_request_marker_update(
   marker->set_action(ignition::msgs::Marker::ADD_MODIFY);
   marker->set_type(ignition::msgs::Marker::LINE_STRIP);
   marker->set_visibility(ignition::msgs::Marker::GUI);
-  marker->mutable_lifetime()->set_sec(9999);
+  marker->mutable_lifetime()->set_sec(0);
 
   ignition::msgs::Set(marker->mutable_material()->mutable_ambient(),
     ignition::math::Color(0, 0, 1, 1));
@@ -437,8 +447,6 @@ void SlotcarPlugin::path_request_marker_update(
       elevation_dir));
   }
 
-  ignition::msgs::Boolean res;
-  bool result;
   _trajectory_marker_node.Request(
     "/marker_array", _trajectory_marker_msg, 5000, res, result);
 }


### PR DESCRIPTION
Signed-off-by: ddengster <ed.fan@osrfoundation.org>

## Bug fix/Added Feature

### Fixed bug

- Using the previous `compute_ds` function with a smaller `s_target` (about `15`) would result in a deceleration that was too large for the vehicle to move. The new function `compute_ds_linear` uses an equation of motion that compute acceleration accordingly based off the remaining displacement, and current and target velocities. ~~Using this function results in office robots not working correctly hence a new function; let it be a TODO for another day.~~ Unified function in PR #57 

- Fixed bug with ackermann steering vehicles not moving when give a single straight line trajectory.

### Added Feature

Add a property, `obey_target_yaw_ackermann` that allows vehicles to obey target yaw of the final waypoint of the trajectory. All ackermann steering robots can use this, it's set to false by default.

Added markers for trajectory message's path
![image](https://user-images.githubusercontent.com/3326941/138247512-353d7820-e4cf-4d15-89a5-0efd07953338.png)
