### PR TITLE
Make holonomic vehicles use new linear motion function

### DIFF
--- a/rmf_robot_sim_common/include/rmf_robot_sim_common/slotcar_common.hpp
+++ b/rmf_robot_sim_common/include/rmf_robot_sim_common/slotcar_common.hpp
@@ -232,6 +232,7 @@ private:
   double _old_ang_vel = 0.0; // Angular velocity at previous time step
   Eigen::Isometry3d _pose; // Pose at current time step
   int _rot_dir = 1; // Current direction of rotation
+  Eigen::Vector3d _rest_position;
 
   std::unordered_map<std::string, double> _level_to_elevation;
   bool _initialized_levels = false;

--- a/rmf_robot_sim_common/include/rmf_robot_sim_common/slotcar_common.hpp
+++ b/rmf_robot_sim_common/include/rmf_robot_sim_common/slotcar_common.hpp
@@ -275,6 +275,7 @@ private:
   double _turning_right_angle_mul_offset = 1.0; // if _min_turning_radius is computed, this value multiplies it
 
   bool _reversible = true; // true if the robot can drive backwards
+  bool _obey_target_yaw_ackermann = false;
 
   PowerParams _params;
   bool _enable_charge = true;
@@ -441,6 +442,11 @@ void SlotcarCommon::read_sdf(SdfPtrT& sdf)
   get_element_val_if_present<SdfPtrT, double>(sdf,
     "base_width", this->_base_width);
   RCLCPP_INFO(logger(), "Setting base width to: %f", _base_width);
+
+  get_element_val_if_present<SdfPtrT, bool>(sdf,
+    "obey_target_yaw_ackermann", this->_obey_target_yaw_ackermann);
+  RCLCPP_INFO(logger(), "Setting _obey_target_yaw_ackermann to: %d",
+    _obey_target_yaw_ackermann);
 
   get_element_val_if_present<SdfPtrT, bool>(sdf,
     "reversible", this->_reversible);

--- a/rmf_robot_sim_common/include/rmf_robot_sim_common/utils.hpp
+++ b/rmf_robot_sim_common/include/rmf_robot_sim_common/utils.hpp
@@ -63,6 +63,15 @@ double compute_ds(
   const double dt,
   const double v_target = 0.0);
 
+double compute_ds_linear(
+  double s_target,
+  double v_actual,
+  const double v_max,
+  const double accel_nom,
+  const double accel_max,
+  const double dt,
+  const double v_target = 0.0);
+
 struct MotionParams
 {
   double v_max = 0.2;

--- a/rmf_robot_sim_common/src/slotcar_common.cpp
+++ b/rmf_robot_sim_common/src/slotcar_common.cpp
@@ -399,11 +399,19 @@ std::array<double, 2> SlotcarCommon::calculate_control_signals(
   const double v_robot = curr_velocities[0];
   const double w_robot = curr_velocities[1];
 
-  const double v_target = rmf_plugins_utils::compute_ds(displacements.first,
-      v_robot,
-      _nominal_drive_speed,
-      _nominal_drive_acceleration, _max_drive_acceleration, dt,
-      target_linear_velocity);
+  double v_target = 0.0;
+  if (this->_steering_type == SteeringType::ACKERMANN)
+    v_target = rmf_plugins_utils::compute_ds_linear(displacements.first,
+        v_robot,
+        _nominal_drive_speed,
+        _nominal_drive_acceleration, _max_drive_acceleration, dt,
+        target_linear_velocity);
+  else
+    v_target = rmf_plugins_utils::compute_ds(displacements.first,
+        v_robot,
+        _nominal_drive_speed,
+        _nominal_drive_acceleration, _max_drive_acceleration, dt,
+        target_linear_velocity);
 
   double w_target = rmf_plugins_utils::compute_ds(displacements.second,
       w_robot,

--- a/rmf_robot_sim_common/src/slotcar_common.cpp
+++ b/rmf_robot_sim_common/src/slotcar_common.cpp
@@ -378,7 +378,7 @@ void SlotcarCommon::handle_ackermann_path_request(
 
   AckermannTrajectory& last_traj = this->ackermann_trajectory.back();
   last_traj.v1 = last_traj.v0;
-  
+
   if (_obey_target_yaw_ackermann)
   {
     // add a turning trajectory to the desired yaw if it differs from the computed one
@@ -424,10 +424,10 @@ void SlotcarCommon::handle_ackermann_path_request(
         tangent_pt = p2 - side_perp;
 
       AckermannTrajectory end_turn_traj(
-          Eigen::Vector2d(tangent_pt.x(), tangent_pt.y()),
-          Eigen::Vector2d(last_traj.x1.x(), last_traj.x1.y()),
-          Eigen::Vector2d(0, 0),
-          true);
+        Eigen::Vector2d(tangent_pt.x(), tangent_pt.y()),
+        Eigen::Vector2d(last_traj.x1.x(), last_traj.x1.y()),
+        Eigen::Vector2d(0, 0),
+        true);
       last_traj.x1 = tangent_pt;
       last_traj.v1 = last_traj.v0;
       end_turn_traj.v0 = last_traj.v1;
@@ -799,10 +799,10 @@ SlotcarCommon::UpdateResult SlotcarCommon::update_ackermann(
       result.speed = _nominal_drive_speed;
     else
     {
-      // last segment, starting from 0 velocity to 
+      // last segment, starting from 0 velocity to
       auto& last_segment = ackermann_trajectory[_ackermann_traj_idx];
       double segment_dist = (last_segment.x1 - last_segment.x0).norm();
-      
+
       if (dpos_mag >= (segment_dist * 0.5))
       {
         // if we're in the first half of the segment,
@@ -846,14 +846,15 @@ SlotcarCommon::UpdateResult SlotcarCommon::update_ackermann(
     // determine turn directionality
     Eigen::Vector2d traj_start_to_dest_pt = dest_pt - traj.x0;
     Eigen::Vector2d start_heading = traj.v0;
-    double cross = start_heading.x() * traj_start_to_dest_pt.y() - start_heading.y() *
+    double cross = start_heading.x() * traj_start_to_dest_pt.y() -
+      start_heading.y() *
       traj_start_to_dest_pt.x();
 
     if (heading_dotp > 0.99 && projection < -0.75)
       result.w = 0.0;
     else
       result.w = cross < 0.0 ? -acos(heading_dotp) : acos(heading_dotp);
-    
+
     close_enough = heading_dotp > 0.99 && projection > 0.0;
   }
 

--- a/rmf_robot_sim_common/src/slotcar_common.cpp
+++ b/rmf_robot_sim_common/src/slotcar_common.cpp
@@ -379,59 +379,62 @@ void SlotcarCommon::handle_ackermann_path_request(
   AckermannTrajectory& last_traj = this->ackermann_trajectory.back();
   last_traj.v1 = last_traj.v0;
   
-  // add a turning trajectory to the desired yaw if it differs from the computed one
-  double prev_yaw = atan2(last_traj.v1.y(), last_traj.v1.x());
-  auto& last_location = locations.back();
-  double desired_yaw = last_location.yaw;
-  double threshold = 5.0 / 180.0 * M_PI;
-  if (std::abs(desired_yaw - prev_yaw) >= threshold)
+  if (_obey_target_yaw_ackermann)
   {
-    double radius = min_turning_radius * 0.5;
+    // add a turning trajectory to the desired yaw if it differs from the computed one
+    double prev_yaw = atan2(last_traj.v1.y(), last_traj.v1.x());
+    auto& last_location = locations.back();
+    double desired_yaw = last_location.yaw;
+    double threshold = 5.0 / 180.0 * M_PI;
+    if (std::abs(desired_yaw - prev_yaw) >= threshold)
+    {
+      double radius = min_turning_radius * 0.5;
 
-    bool turn_left = prev_yaw < desired_yaw;
-    Eigen::Vector2d circle_position;
-    Eigen::Vector2d tangent_to_circle;
+      bool turn_left = prev_yaw < desired_yaw;
+      Eigen::Vector2d circle_position;
+      Eigen::Vector2d tangent_to_circle;
 
-    Eigen::Vector2d v = Eigen::Vector2d(cos(desired_yaw), sin(desired_yaw));
-    Eigen::Vector2d v_perp = Eigen::Vector2d(v.y(), -v.x());
+      Eigen::Vector2d v = Eigen::Vector2d(cos(desired_yaw), sin(desired_yaw));
+      Eigen::Vector2d v_perp = Eigen::Vector2d(v.y(), -v.x());
 
-    if (turn_left)
-      circle_position = last_traj.x1 - v_perp * radius;
-    else // turn right
-      circle_position = last_traj.x1 + v_perp * radius;
+      if (turn_left)
+        circle_position = last_traj.x1 - v_perp * radius;
+      else // turn right
+        circle_position = last_traj.x1 + v_perp * radius;
 
-    // solve for tangent point
-    // https://web.archive.org/web/20210124122457/http://csharphelper.com/blog/2014/09/determine-where-two-circles-intersect-in-c/
-    Eigen::Vector2d p0 = last_traj.x0;
-    Eigen::Vector2d p1 = circle_position;
-    Eigen::Vector2d p0_to_p1 = p1 - p0;
-    double d = p0_to_p1.norm();
-    double r1 = radius;
-    double r0 = sqrt(d * d - r1 * r1);
-    double a = (r0 * r0 - r1 * r1 + d * d) / (2.0 * d);
-    double h = sqrt(r0 * r0 - a * a);
+      // solve for tangent point
+      // https://web.archive.org/web/20210124122457/http://csharphelper.com/blog/2014/09/determine-where-two-circles-intersect-in-c/
+      Eigen::Vector2d p0 = last_traj.x0;
+      Eigen::Vector2d p1 = circle_position;
+      Eigen::Vector2d p0_to_p1 = p1 - p0;
+      double d = p0_to_p1.norm();
+      double r1 = radius;
+      double r0 = sqrt(d * d - r1 * r1);
+      double a = (r0 * r0 - r1 * r1 + d * d) / (2.0 * d);
+      double h = sqrt(r0 * r0 - a * a);
 
-    Eigen::Vector2d p2 = p0 + (p0_to_p1 / d) * a;
-    Eigen::Vector2d side = (p0_to_p1 / d) * h;
-    Eigen::Vector2d side_perp = Eigen::Vector2d(side.y(), -side.x());
+      Eigen::Vector2d p2 = p0 + (p0_to_p1 / d) * a;
+      Eigen::Vector2d side = (p0_to_p1 / d) * h;
+      Eigen::Vector2d side_perp = Eigen::Vector2d(side.y(), -side.x());
 
-    Eigen::Vector2d tangent_pt;
-    if (turn_left)
-      tangent_pt = p2 + side_perp;
-    else
-      tangent_pt = p2 - side_perp;
+      Eigen::Vector2d tangent_pt;
+      if (turn_left)
+        tangent_pt = p2 + side_perp;
+      else
+        tangent_pt = p2 - side_perp;
 
-    AckermannTrajectory end_turn_traj(
-        Eigen::Vector2d(tangent_pt.x(), tangent_pt.y()),
-        Eigen::Vector2d(last_traj.x1.x(), last_traj.x1.y()),
-        Eigen::Vector2d(0, 0),
-        true);
-    last_traj.x1 = tangent_pt;
-    last_traj.v1 = last_traj.v0;
-    end_turn_traj.v0 = last_traj.v1;
-    end_turn_traj.v1 = v;
+      AckermannTrajectory end_turn_traj(
+          Eigen::Vector2d(tangent_pt.x(), tangent_pt.y()),
+          Eigen::Vector2d(last_traj.x1.x(), last_traj.x1.y()),
+          Eigen::Vector2d(0, 0),
+          true);
+      last_traj.x1 = tangent_pt;
+      last_traj.v1 = last_traj.v0;
+      end_turn_traj.v0 = last_traj.v1;
+      end_turn_traj.v1 = v;
 
-    this->ackermann_trajectory.push_back(end_turn_traj);
+      this->ackermann_trajectory.push_back(end_turn_traj);
+    }
   }
 }
 

--- a/rmf_robot_sim_common/src/slotcar_common.cpp
+++ b/rmf_robot_sim_common/src/slotcar_common.cpp
@@ -394,7 +394,7 @@ void SlotcarCommon::handle_ackermann_path_request(
 
     Eigen::Vector2d v = Eigen::Vector2d(cos(desired_yaw), sin(desired_yaw));
     Eigen::Vector2d v_perp = Eigen::Vector2d(v.y(), -v.x());
-    std::cout << v_perp << std::endl;
+
     if (turn_left)
       circle_position = last_traj.x1 - v_perp * radius;
     else // turn right

--- a/rmf_robot_sim_common/src/utils.cpp
+++ b/rmf_robot_sim_common/src/utils.cpp
@@ -59,6 +59,54 @@ double compute_ds(
 }
 
 //==============================================================================
+double compute_ds_linear(
+  double s_target,
+  double v_actual,
+  const double v_max,
+  const double accel_nom,
+  const double accel_max,
+  const double dt,
+  const double v_target)
+{
+  double sign = 1.0;
+  if (s_target < 0.0)
+  {
+    // Limits get confusing when we need to go backwards, so we'll flip signs
+    // here so that we pretend the target is forwards
+    s_target *= -1.0;
+    v_actual *= -1.0;
+    sign = -1.0;
+  }
+
+  // We should try not to shoot past the targstd::vector<event::ConnectionPtr> connections;et
+  double next_v = s_target / dt;
+
+  // Test velocity limit
+  next_v = std::min(next_v, v_max);
+
+  // Test acceleration limit
+  next_v = std::min(next_v, accel_nom * dt + v_actual);
+
+  if (v_actual > 0.0 && s_target > 0.0)
+  {
+    // use equations of motion to figure out an acceleration
+    double desired_acceleration = (pow(v_target, 2) - pow(v_actual, 2)) / (2.0 * s_target);
+    if (desired_acceleration > accel_max)
+      desired_acceleration = accel_max;
+
+    next_v = desired_acceleration * dt + v_actual;
+  }
+
+  // if you have a target velocity and a distance shorter than that, set to
+  // the target velocity otherwise it'll hard-stop
+  if (s_target < v_target)
+    next_v = v_target;
+
+  // Flip the sign the to correct direction before returning the value
+  return sign * next_v;
+}
+
+//==============================================================================
 double compute_desired_rate_of_change(
   double _s_target,
   double _v_actual,

--- a/rmf_robot_sim_common/src/utils.cpp
+++ b/rmf_robot_sim_common/src/utils.cpp
@@ -90,7 +90,8 @@ double compute_ds_linear(
   if (v_actual > 0.0 && s_target > 0.0)
   {
     // use equations of motion to figure out an acceleration
-    double desired_acceleration = (pow(v_target, 2) - pow(v_actual, 2)) / (2.0 * s_target);
+    double desired_acceleration =
+      (pow(v_target, 2) - pow(v_actual, 2)) / (2.0 * s_target);
     if (desired_acceleration > accel_max)
       desired_acceleration = accel_max;
 


### PR DESCRIPTION
## New feature implementation

### Implemented feature/bugfix

With changes in #54 ackermann steering vehicles had to use a different motion function that takes advantage of a target speed. This PR makes diff drive vehicles make use of the same function as well without no-move bugs.

Relevant changes are in 38f4bcf, the rest of the commits are based off `fix/motion`. The changes are done in this separate PR because this could break many of our other simulations.
