### PR TITLE
Update robot's current level only after the lift has finished moving

### DIFF
--- a/rmf_robot_sim_common/include/rmf_robot_sim_common/slotcar_common.hpp
+++ b/rmf_robot_sim_common/include/rmf_robot_sim_common/slotcar_common.hpp
@@ -235,6 +235,7 @@ private:
 
   std::unordered_map<std::string, double> _level_to_elevation;
   bool _initialized_levels = false;
+  std::string _last_known_level;
 
   std::shared_ptr<tf2_ros::TransformBroadcaster> _tf2_broadcaster;
   rclcpp::Publisher<rmf_fleet_msgs::msg::RobotState>::SharedPtr _robot_state_pub;
@@ -293,7 +294,7 @@ private:
 
   bool _docking = false;
 
-  std::string get_level_name(const double z) const;
+  std::string get_level_name(const double z);
 
   double compute_change_in_rotation(
     const Eigen::Vector3d& heading_vec,

--- a/rmf_robot_sim_common/include/rmf_robot_sim_common/slotcar_common.hpp
+++ b/rmf_robot_sim_common/include/rmf_robot_sim_common/slotcar_common.hpp
@@ -235,7 +235,7 @@ private:
 
   std::unordered_map<std::string, double> _level_to_elevation;
   bool _initialized_levels = false;
-  std::string _last_known_level;
+  std::string _last_known_level = "";
 
   std::shared_ptr<tf2_ros::TransformBroadcaster> _tf2_broadcaster;
   rclcpp::Publisher<rmf_fleet_msgs::msg::RobotState>::SharedPtr _robot_state_pub;

--- a/rmf_robot_sim_common/src/slotcar_common.cpp
+++ b/rmf_robot_sim_common/src/slotcar_common.cpp
@@ -802,23 +802,22 @@ bool SlotcarCommon::emergency_stop(
   return _emergency_stop;
 }
 
-std::string SlotcarCommon::get_level_name(const double z) const
+std::string SlotcarCommon::get_level_name(const double z)
 {
-  std::string level_name = "";
   if (!_initialized_levels)
-    return level_name;
-  auto min_distance = std::numeric_limits<double>::max();
+    return "";
   for (auto it = _level_to_elevation.begin(); it != _level_to_elevation.end();
     ++it)
   {
     const double disp = std::abs(it->second - z);
-    if (disp < min_distance)
+    if (disp < 0.1)
     {
-      min_distance = disp;
-      level_name = it->first;
+      _last_known_level = it->first;
+      return _last_known_level;
     }
   }
-  return level_name;
+  // Robot is transitioning between levels so return last known level
+  return _last_known_level;
 }
 
 double SlotcarCommon::compute_change_in_rotation(
@@ -987,7 +986,7 @@ void SlotcarCommon::charge_state_cb(
 
 bool SlotcarCommon::near_charger(const Eigen::Isometry3d& pose) const
 {
-  std::string lvl_name = get_level_name(pose.translation()[2]);
+  std::string lvl_name = _last_known_level;
   auto waypoints_it = _charger_waypoints.find(lvl_name);
   if (waypoints_it != _charger_waypoints.end())
   {


### PR DESCRIPTION
This PR updates the `level_name` for a robot only once it has reached the new level. The previous implementation used to report whichever level's elevation was nearest. As a consequence the current level of the robot would switch while it is transitioning inside an elevator. This was causing problems with 1) Visualization of the robot's position and 2) State estimations when updating the robot's position with the fleet adapter.