### PR TITLE
Slotcar pursues a lookahead point on its path. Add display markers fo…

### DIFF
--- a/rmf_robot_sim_common/include/rmf_robot_sim_common/slotcar_common.hpp
+++ b/rmf_robot_sim_common/include/rmf_robot_sim_common/slotcar_common.hpp
@@ -243,6 +243,7 @@ private:
   // Assumes robot is stationary upon initialization
   Eigen::Vector3d _old_lin_vel = Eigen::Vector3d::Zero(); // Linear velocity at previous time step
   double _old_ang_vel = 0.0; // Angular velocity at previous time step
+  bool _was_rotating; // Whether robot was rotating towards its next target in previous time step
   Eigen::Isometry3d _pose; // Pose at current time step
   int _rot_dir = 1; // Current direction of rotation
 

--- a/rmf_robot_sim_common/include/rmf_robot_sim_common/slotcar_common.hpp
+++ b/rmf_robot_sim_common/include/rmf_robot_sim_common/slotcar_common.hpp
@@ -126,7 +126,8 @@ public:
   {
     double v = 0.0; // Target displacement in X (forward)
     double w = 0.0; // Target displacement in yaw
-    double speed = 0.0; // Target speed at next waypoint
+    double target_linear_speed_now = 0.0;     // Target linear speed now
+    double target_linear_speed_destination = 0.0; // Target linear speed at destination
     std::optional<double> max_speed = std::nullopt; // Maximum speed allowed while navigating
   };
 
@@ -161,14 +162,16 @@ public:
     2>& curr_velocities,
     const std::pair<double, double>& displacements,
     const double dt,
-    const double target_linear_velocity = 0.0,
+    const double target_velocity_now = 0.0,
+    const double target_velocity_at_dest = 0.0,
     const std::optional<double>& linear_speed_limit = std::nullopt) const;
 
   std::array<double, 2> calculate_joint_control_signals(
     const std::array<double, 2>& w_tire,
     const std::pair<double, double>& displacements,
     const double dt,
-    const double target_linear_velocity = 0.0,
+    const double target_linear_speed_now = 0.0,
+    const double target_linear_speed_destination = 0.0,
     const std::optional<double>& linear_speed_limit = std::nullopt) const;
 
   void charge_state_cb(const std::string& name, bool selected);

--- a/rmf_robot_sim_common/include/rmf_robot_sim_common/slotcar_common.hpp
+++ b/rmf_robot_sim_common/include/rmf_robot_sim_common/slotcar_common.hpp
@@ -131,13 +131,6 @@ public:
     std::optional<double> max_speed = std::nullopt; // Maximum speed allowed while navigating
   };
 
-  // Ignition plugin reads this to display markers
-  struct PursuitState
-  {
-    Eigen::Vector3d lookahead_point = Eigen::Vector3d::Zero();
-    std::size_t traj_wp_idx;
-  };
-
   SlotcarCommon();
 
   rclcpp::Logger logger() const;
@@ -178,7 +171,7 @@ public:
 
   void publish_robot_state(const double time);
 
-  PursuitState get_pursuit_state() const;
+  Eigen::Vector3d get_lookahead_point() const;
 
   bool display_markers = false; // Ignition only: toggles display of waypoint and lookahead markers
 
@@ -307,7 +300,7 @@ private:
 
   bool _docking = false;
 
-  PursuitState _pursuit_state;
+  Eigen::Vector3d _lookahead_point;
   double _lookahead_distance = 8.0;
 
   PathRequestCallback _path_request_callback = nullptr;

--- a/rmf_robot_sim_common/include/rmf_robot_sim_common/slotcar_common.hpp
+++ b/rmf_robot_sim_common/include/rmf_robot_sim_common/slotcar_common.hpp
@@ -178,11 +178,14 @@ public:
 
   void publish_robot_state(const double time);
 
-  void get_pursuit_state(PursuitState& pursuit_state);
-
-  void get_trajectory(std::vector<SlotcarTrajectory>& traj);
+  PursuitState get_pursuit_state() const;
 
   bool display_markers = false; // Ignition only: toggles display of waypoint and lookahead markers
+
+  using PathRequestCallback =
+    std::function<void(const rmf_fleet_msgs::msg::PathRequest::SharedPtr)>;
+  void set_path_request_callback(PathRequestCallback cb)
+  { _path_request_callback = cb; }
 
 private:
   // Parameters needed for power dissipation and charging calculations
@@ -305,6 +308,8 @@ private:
 
   PursuitState _pursuit_state;
   double _lookahead_distance = 8.0;
+
+  PathRequestCallback _path_request_callback = nullptr;
 
   std::string get_level_name(const double z) const;
 

--- a/rmf_robot_sim_common/include/rmf_robot_sim_common/utils.hpp
+++ b/rmf_robot_sim_common/include/rmf_robot_sim_common/utils.hpp
@@ -52,16 +52,6 @@ struct SimEntity
 };
 
 /////////////////////////////////////////////////////////////////////////////////////////////////
-// TODO(MXG): Refactor the use of this function to replace it with
-// compute_desired_rate_of_change()
-double compute_ds(
-  double s_target,
-  double v_actual,
-  const double v_max,
-  const double accel_nom,
-  const double accel_max,
-  const double dt,
-  const double v_target = 0.0);
 
 struct MotionParams
 {
@@ -73,8 +63,10 @@ struct MotionParams
 };
 
 double compute_desired_rate_of_change(
-  double _s_target,
-  double _v_actual,
+  double _s_target,              // Displacement to destination
+  double _v_actual,              // Current velocity
+  double _speed_target_now,      // Target speed now while on route
+  double _speed_target_dest,     // Target speed at destination
   const MotionParams& _motion_params,
   const double _dt);
 

--- a/rmf_robot_sim_common/src/slotcar_common.cpp
+++ b/rmf_robot_sim_common/src/slotcar_common.cpp
@@ -88,7 +88,7 @@ double compute_friction_energy(
 
 // Given a line segment from point1 to point2, and a circle centred at (cx, cy),
 // returns the points of intersection.
-std::vector<Eigen::Vector2d> line_circle_intersections(
+static std::vector<Eigen::Vector2d> line_circle_intersections(
   const Eigen::Vector2d point1,
   const Eigen::Vector2d point2,
   const double cx,
@@ -141,7 +141,7 @@ std::vector<Eigen::Vector2d> line_circle_intersections(
 
 // Returns the point on the line segment from A to B that is
 // closest to point P.
-Eigen::Vector2d get_closest_point_on_line_segment(
+static Eigen::Vector2d get_closest_point_on_line_segment(
   Eigen::Vector2d A,
   Eigen::Vector2d B,
   Eigen::Vector2d P)
@@ -820,14 +820,10 @@ SlotcarCommon::UpdateResult SlotcarCommon::update_ackermann(
         }
       }
 
-      auto target_3d = Eigen::Vector3d(target(0), target(1),
+      _lookahead_point = Eigen::Vector3d(target(0), target(1),
           trajectory.at(_traj_wp_idx).pose.translation()(2));
-      _pursuit_state.lookahead_point(0) = target_3d(0);
-      _pursuit_state.lookahead_point(1) = target_3d(1);
-      _pursuit_state.lookahead_point(2) = target_3d(2);
-      _pursuit_state.traj_wp_idx = _traj_wp_idx;
 
-      Eigen::Vector3d d_target = target_3d - _pose.translation();
+      Eigen::Vector3d d_target = _lookahead_point - _pose.translation();
 
       result.v = d_target.norm();
 
@@ -1140,7 +1136,7 @@ double SlotcarCommon::compute_discharge(
   return dSOC;
 }
 
-SlotcarCommon::PursuitState SlotcarCommon::get_pursuit_state() const
+Eigen::Vector3d SlotcarCommon::get_lookahead_point() const
 {
-  return _pursuit_state;
+  return _lookahead_point;
 }

--- a/rmf_robot_sim_common/src/slotcar_common.cpp
+++ b/rmf_robot_sim_common/src/slotcar_common.cpp
@@ -553,7 +553,9 @@ SlotcarCommon::UpdateResult SlotcarCommon::update_diff_drive(
     const auto hold_time =
       rclcpp::Time(_hold_times.at(_traj_wp_idx), RCL_ROS_TIME);
 
-    const bool close_enough = (dpos_mag < 0.02);
+    bool close_enough = (dpos_mag < 0.02);
+    if (_was_rotating) // Accomodate slight drift when rotating on the spot
+      close_enough = (dpos_mag < 0.04);
 
     const bool checkpoint_pause =
       pause_request.type == pause_request.TYPE_PAUSE_AT_CHECKPOINT
@@ -565,6 +567,7 @@ SlotcarCommon::UpdateResult SlotcarCommon::update_diff_drive(
     const bool hold = now < hold_time;
 
     const bool rotate_towards_next_target = close_enough && (hold || pause);
+    _was_rotating = rotate_towards_next_target;
 
     if (rotate_towards_next_target)
     {

--- a/rmf_robot_sim_common/src/utils.cpp
+++ b/rmf_robot_sim_common/src/utils.cpp
@@ -15,18 +15,14 @@ double compute_desired_rate_of_change(
   const MotionParams& _motion_params,
   const double _dt)
 {
-  using std::copysign;
-  using std::min;
-  using std::signbit;
-
-  bool v_opposite_s = abs(_v_actual) > 0 &&
-    (signbit(_v_actual) != signbit(_s_target));
+  bool v_opposite_s = abs(_v_actual) > 0.0 &&
+    (std::signbit(_v_actual) != std::signbit(_s_target));
 
   if (abs(_s_target) == 0.0 || v_opposite_s)
   {
-    // Use maximum accleration to come to a stop
-    double v_difference = copysign(
-      min(abs(_v_actual), _motion_params.a_max * _dt),
+    // Use maximum acceleration to come to a stop
+    double v_difference = std::copysign(
+      std::min(abs(_v_actual), _motion_params.a_max * _dt),
       _v_actual);
     return _v_actual - v_difference;
   }
@@ -36,8 +32,8 @@ double compute_desired_rate_of_change(
   double required_accel =
     (pow(_speed_target_dest, 2) - pow(_v_actual, 2)) / (2.0 * _s_target);
   // Test acceleration limit
-  required_accel = copysign(
-    min(abs(required_accel), _motion_params.a_max),
+  required_accel = std::copysign(
+    std::min(abs(required_accel), _motion_params.a_max),
     required_accel);
   if (abs(required_accel) >= _motion_params.a_nom)
   {
@@ -50,13 +46,13 @@ double compute_desired_rate_of_change(
   }
 
   // Test target speed limit
-  double v_target_now = copysign(
-    min(abs(_speed_target_now), _motion_params.v_max), _s_target);
+  double v_target_now = std::copysign(
+    std::min(abs(_speed_target_now), _motion_params.v_max), _s_target);
 
   // Test acceleration limit
   double v_change = v_target_now - _v_actual;
-  v_change = copysign(
-    min(abs(v_change), _motion_params.a_nom * _dt), v_change);
+  v_change = std::copysign(
+    std::min(abs(v_change), _motion_params.a_nom * _dt), v_change);
   double v_next = _v_actual + v_change;
   return v_next;
 }

--- a/rmf_robot_sim_common/src/utils.cpp
+++ b/rmf_robot_sim_common/src/utils.cpp
@@ -15,6 +15,15 @@ double compute_desired_rate_of_change(
   const MotionParams& _motion_params,
   const double _dt)
 {
+  // When velocity is the opposite direction of displacement, stop. But for
+  // very small velocities, the physics engine may not register the small
+  // change required to decelerate to 0.0, so we need to do rounding.
+  double eps = 1e-4;
+  if (abs(_v_actual) < eps)
+  {
+    _v_actual = 0.0;
+  }
+
   bool v_opposite_s = abs(_v_actual) > 0.0 &&
     (std::signbit(_v_actual) != std::signbit(_s_target));
 

--- a/rmf_robot_sim_common/src/utils.cpp
+++ b/rmf_robot_sim_common/src/utils.cpp
@@ -49,7 +49,13 @@ double compute_desired_rate_of_change(
   double v_target_now = std::copysign(
     std::min(abs(_speed_target_now), _motion_params.v_max), _s_target);
 
-  // Test acceleration limit
+  // When extremely near destination, don't accelerate to _speed_target_now.
+  if (abs((_v_actual + _motion_params.a_nom) * _dt) > abs(_s_target)) {
+    v_target_now = std::copysign(
+     std::max(abs(_s_target/_dt), _speed_target_dest), _s_target);
+  }
+
+  // Test acceleration
   double v_change = v_target_now - _v_actual;
   v_change = std::copysign(
     std::min(abs(v_change), _motion_params.a_nom * _dt), v_change);

--- a/rmf_robot_sim_common/src/utils.cpp
+++ b/rmf_robot_sim_common/src/utils.cpp
@@ -25,7 +25,7 @@ double compute_ds(
     sign = -1.0;
   }
 
-  // We should try not to shoot past the targstd::vector<event::ConnectionPtr> connections;et
+  // We should try not to shoot past the target
   double next_v = s_target / dt;
 
   // Test velocity limit
@@ -44,14 +44,16 @@ double compute_ds(
     if (accel_nom <= deceleration)
     {
       // If the smallest constant deceleration for reaching the goal is
-      // greater than
+      // greater than the nominal acceleration, then we should begin
+      // decelerating right away so that we can smoothly reach the goal while
+      // decelerating as close to the nominal acceleration as possible.
       next_v = -deceleration * dt + v_actual;
     }
   }
 
   // if you have a target velocity and a distance shorter than that, set to
   // the target velocity otherwise it'll hard-stop
-  if (s_target < v_target)
+  if (s_target <= v_target)
     next_v = v_target;
 
   // Flip the sign the to correct direction before returning the value

--- a/rmf_robot_sim_common/src/utils.cpp
+++ b/rmf_robot_sim_common/src/utils.cpp
@@ -6,105 +6,59 @@
 namespace rmf_plugins_utils {
 
 //==============================================================================
-double compute_ds(
-  double s_target,
-  double v_actual,
-  const double v_max,
-  const double accel_nom,
-  const double accel_max,
-  const double dt,
-  const double v_target)
-{
-  double sign = 1.0;
-  if (s_target < 0.0)
-  {
-    // Limits get confusing when we need to go backwards, so we'll flip signs
-    // here so that we pretend the target is forwards
-    s_target *= -1.0;
-    v_actual *= -1.0;
-    sign = -1.0;
-  }
 
-  // We should try not to shoot past the target
-  double next_v = s_target / dt;
-
-  // Test velocity limit
-  next_v = std::min(next_v, v_max);
-
-  // Test acceleration limit
-  next_v = std::min(next_v, accel_nom * dt + v_actual);
-
-  if (v_actual > 0.0 && s_target > 0.0)
-  {
-    // This is what our deceleration should be if we want to begin a constant
-    // deceleration from now until we reach the goal
-    double deceleration = pow(v_actual - v_target, 2) / s_target;
-    deceleration = std::min(deceleration, accel_max);
-
-    if (accel_nom <= deceleration)
-    {
-      // If the smallest constant deceleration for reaching the goal is
-      // greater than the nominal acceleration, then we should begin
-      // decelerating right away so that we can smoothly reach the goal while
-      // decelerating as close to the nominal acceleration as possible.
-      next_v = -deceleration * dt + v_actual;
-    }
-  }
-
-  // if you have a target velocity and a distance shorter than that, set to
-  // the target velocity otherwise it'll hard-stop
-  if (s_target <= v_target)
-    next_v = v_target;
-
-  // Flip the sign the to correct direction before returning the value
-  return sign * next_v;
-}
-
-//==============================================================================
 double compute_desired_rate_of_change(
   double _s_target,
   double _v_actual,
+  double _speed_target_now,
+  double _speed_target_dest,
   const MotionParams& _motion_params,
   const double _dt)
 {
-  double sign = 1.0;
-  if (_s_target < 0.0)
+  using std::copysign;
+  using std::min;
+  using std::signbit;
+
+  bool v_opposite_s = abs(_v_actual) > 0 &&
+    (signbit(_v_actual) != signbit(_s_target));
+
+  if (abs(_s_target) == 0.0 || v_opposite_s)
   {
-    // Limits get confusing when we need to go backwards, so we'll flip signs
-    // here so that we pretend the target is forwards
-    _s_target *= -1.0;
-    _v_actual *= -1.0;
-    sign = -1.0;
+    // Use maximum accleration to come to a stop
+    double v_difference = copysign(
+      min(abs(_v_actual), _motion_params.a_max * _dt),
+      _v_actual);
+    return _v_actual - v_difference;
   }
 
-  // We should try not to shoot past the target
-  double v_next = _s_target / _dt;
+  // This is what our acceleration should be if we want to begin a constant
+  // acceleration from now until we reach the goal with _speed_target_dest
+  double required_accel =
+    (pow(_speed_target_dest, 2) - pow(_v_actual, 2)) / (2.0 * _s_target);
+  // Test acceleration limit
+  required_accel = copysign(
+    min(abs(required_accel), _motion_params.a_max),
+    required_accel);
+  if (abs(required_accel) >= _motion_params.a_nom)
+  {
+    // If the smallest constant acceleration for reaching the goal is
+    // greater than the nominal acceleration, then we should begin
+    // accelerating right away so that we can smoothly reach the goal while
+    // accelerating as close to the nominal acceleration as possible.
+    double v_next = required_accel * _dt + _v_actual;
+    return v_next;
+  }
 
-  // Test velocity limit
-  v_next = std::min(v_next, _motion_params.v_max);
+  // Test target speed limit
+  double v_target_now = copysign(
+    min(abs(_speed_target_now), _motion_params.v_max), _s_target);
 
   // Test acceleration limit
-  v_next = std::min(v_next, _motion_params.a_nom * _dt + _v_actual);
-
-  if (_v_actual > 0.0 && _s_target > 0.0)
-  {
-    // This is what our deceleration should be if we want to begin a constant
-    // deceleration from now until we reach the goal
-    double deceleration = pow(_v_actual, 2) / (2.0 * _s_target);
-    deceleration = std::min(deceleration, _motion_params.a_max);
-
-    if (_motion_params.a_nom <= deceleration)
-    {
-      // If the smallest constant deceleration for reaching the goal is
-      // greater than the nominal acceleration, then we should begin
-      // decelerating right away so that we can smoothly reach the goal while
-      // decelerating as close to the nominal acceleration as possible.
-      v_next = -deceleration * _dt + _v_actual;
-    }
-  }
-
-  // Flip the sign the to correct direction before returning the value
-  return sign * v_next;
+  double v_change = v_target_now - _v_actual;
+  v_change = copysign(
+    min(abs(v_change), _motion_params.a_nom * _dt), v_change);
+  double v_next = _v_actual + v_change;
+  return v_next;
 }
 
 //================================================================================

--- a/rmf_robot_sim_common/src/utils.cpp
+++ b/rmf_robot_sim_common/src/utils.cpp
@@ -50,9 +50,10 @@ double compute_desired_rate_of_change(
     std::min(abs(_speed_target_now), _motion_params.v_max), _s_target);
 
   // When extremely near destination, don't accelerate to _speed_target_now.
-  if (abs((_v_actual + _motion_params.a_nom) * _dt) > abs(_s_target)) {
+  if (abs((_v_actual + _motion_params.a_nom) * _dt) > abs(_s_target))
+  {
     v_target_now = std::copysign(
-     std::max(abs(_s_target/_dt), _speed_target_dest), _s_target);
+      std::max(abs(_s_target/_dt), _speed_target_dest), _s_target);
   }
 
   // Test acceleration

--- a/rmf_robot_sim_gazebo_plugins/src/slotcar.cpp
+++ b/rmf_robot_sim_gazebo_plugins/src/slotcar.cpp
@@ -43,14 +43,17 @@ private:
   void charge_state_cb(ConstSelectionPtr& msg);
 
   void send_control_signals(const std::pair<double, double>& displacements,
-    const double dt, const double target_linear_velocity,
+    const double dt, const double target_linear_speed_now,
+    const double target_linear_speed_destination,
     const std::optional<double>& max_linear_velocity)
   {
     std::array<double, 2> w_tire;
     for (std::size_t i = 0; i < 2; ++i)
       w_tire[i] = joints[i]->GetVelocity(0);
     auto joint_signals = dataPtr->calculate_joint_control_signals(w_tire,
-        displacements, dt, target_linear_velocity, max_linear_velocity);
+        displacements, dt, target_linear_speed_now,
+        target_linear_speed_destination,
+        max_linear_velocity);
     for (std::size_t i = 0; i < 2; ++i)
     {
       joints[i]->SetParam("vel", 0, joint_signals[i]);
@@ -170,7 +173,9 @@ void SlotcarPlugin::OnUpdate()
       obstacle_positions, time);
 
   send_control_signals({update_result.v, update_result.w}, dt,
-    update_result.speed, update_result.max_speed);
+    update_result.target_linear_speed_now,
+    update_result.target_linear_speed_destination,
+    update_result.max_speed);
 }
 
 GZ_REGISTER_MODEL_PLUGIN(SlotcarPlugin)

--- a/rmf_robot_sim_ignition_plugins/src/slotcar.cpp
+++ b/rmf_robot_sim_ignition_plugins/src/slotcar.cpp
@@ -343,6 +343,7 @@ void SlotcarPlugin::draw_markers()
   line_marker.set_action(ignition::msgs::Marker::ADD_MODIFY);
   line_marker.set_type(ignition::msgs::Marker::LINE_STRIP);
   line_marker.set_visibility(ignition::msgs::Marker::GUI);
+  line_marker.mutable_lifetime()->set_sec(1);
   ignition::msgs::Set(
     line_marker.mutable_material()->mutable_ambient(),
     ignition::math::Color(1, 0, 0, 1));
@@ -372,6 +373,7 @@ void SlotcarPlugin::draw_markers()
     waypoint_marker.set_action(ignition::msgs::Marker::ADD_MODIFY);
     waypoint_marker.set_type(ignition::msgs::Marker::SPHERE);
     waypoint_marker.set_visibility(ignition::msgs::Marker::GUI);
+    waypoint_marker.mutable_lifetime()->set_sec(1);
     ignition::msgs::Set(waypoint_marker.mutable_scale(),
       ignition::math::Vector3d(1.5, 1.5, 1.5));
     ignition::msgs::Set(

--- a/rmf_robot_sim_ignition_plugins/src/slotcar.cpp
+++ b/rmf_robot_sim_ignition_plugins/src/slotcar.cpp
@@ -392,7 +392,7 @@ void SlotcarPlugin::path_request_marker_update(
     ignition::msgs::Set(marker_headings->add_point(),
       ignition::math::Vector3d(loc.x, loc.y, elevation));
     ignition::msgs::Set(marker_headings->add_point(),
-      ignition::math::Vector3d(loc.x + length * dir.x(), 
+      ignition::math::Vector3d(loc.x + length * dir.x(),
       loc.y + length * dir.y(),
       elevation+0.5));
   }

--- a/rmf_robot_sim_ignition_plugins/src/slotcar.cpp
+++ b/rmf_robot_sim_ignition_plugins/src/slotcar.cpp
@@ -81,7 +81,13 @@ private:
     ignition::msgs::Double& rep);
   std::vector<Eigen::Vector3d> get_obstacle_positions(
     EntityComponentManager& ecm);
-  void draw_markers();
+
+  void path_request_marker_update(
+    const rmf_fleet_msgs::msg::PathRequest::SharedPtr);
+
+  void draw_lookahead_marker();
+
+  ignition::msgs::Marker_V _trajectory_marker_msg;
 };
 
 SlotcarPlugin::SlotcarPlugin()
@@ -158,6 +164,12 @@ void SlotcarPlugin::Configure(const Entity& entity,
     std::cerr << "Error subscribing to topic [/slotcar_height]" << std::endl;
   }
 
+  if (dataPtr->display_markers)
+  {
+    dataPtr->set_path_request_callback(std::bind(&SlotcarPlugin::
+      path_request_marker_update,
+      this, std::placeholders::_1));
+  }
 }
 
 void SlotcarPlugin::send_control_signals(EntityComponentManager& ecm,
@@ -308,13 +320,92 @@ bool SlotcarPlugin::get_slotcar_height(const ignition::msgs::Entity& req,
   return false;
 }
 
-void SlotcarPlugin::draw_markers()
+void SlotcarPlugin::path_request_marker_update(
+  const rmf_fleet_msgs::msg::PathRequest::SharedPtr msg)
 {
-  rmf_robot_sim_common::SlotcarCommon::PursuitState pursuit_state;
-  dataPtr->get_pursuit_state(pursuit_state);
-  auto traj_wp_idx = pursuit_state.traj_wp_idx;
-  std::vector<rmf_robot_sim_common::SlotcarTrajectory> trajectory;
-  dataPtr->get_trajectory(trajectory);
+  ignition::msgs::Boolean res;
+  bool result;
+  for (int i = 0; i < _trajectory_marker_msg.marker_size(); ++i)
+  {
+    auto marker = _trajectory_marker_msg.mutable_marker(i);
+    marker->set_action(ignition::msgs::Marker::DELETE_ALL);
+  }
+  _ign_node.Request(
+    "/marker_array", _trajectory_marker_msg, 5000, res, result);
+
+  // _trajectory_marker_msg.clear_marker();
+
+  auto line_marker = _trajectory_marker_msg.add_marker();
+  line_marker->set_ns(dataPtr->model_name() + "_line");
+  line_marker->set_id(1);
+  line_marker->set_action(ignition::msgs::Marker::ADD_MODIFY);
+  line_marker->set_type(ignition::msgs::Marker::LINE_STRIP);
+  line_marker->set_visibility(ignition::msgs::Marker::GUI);
+  ignition::msgs::Set(
+    line_marker->mutable_material()->mutable_ambient(),
+    ignition::math::Color(1, 0, 0, 1));
+  ignition::msgs::Set(
+    line_marker->mutable_material()->mutable_diffuse(),
+    ignition::math::Color(1, 0, 0, 1));
+
+  auto marker_headings = _trajectory_marker_msg.add_marker();
+  marker_headings->set_id(1);
+  marker_headings->set_ns(dataPtr->model_name() + "_waypoint_headings");
+  marker_headings->set_action(ignition::msgs::Marker::ADD_MODIFY);
+  marker_headings->set_type(ignition::msgs::Marker::LINE_LIST);
+  marker_headings->set_visibility(ignition::msgs::Marker::GUI);
+  ignition::msgs::Set(marker_headings->mutable_material()->mutable_ambient(),
+    ignition::math::Color(0, 1, 0, 1));
+  ignition::msgs::Set(marker_headings->mutable_material()->mutable_diffuse(),
+    ignition::math::Color(0, 1, 0, 1));
+
+  auto& locations = msg->path;
+  double elevation = 0.5;
+  for (size_t i = 0; i < locations.size(); ++i)
+  {
+    auto loc = locations[i];
+
+    // Add points to the trajectory line, slightly elevated for visibility.
+    ignition::msgs::Set(line_marker->add_point(),
+      ignition::math::Vector3d(loc.x, loc.y, elevation)
+    );
+
+    // Draw waypoints
+    ignition::math::Color waypoint_color(0.0, 1.0, 0.0, 1.0);
+    auto waypoint_marker = _trajectory_marker_msg.add_marker();
+    waypoint_marker->set_ns(dataPtr->model_name() + "_waypoints");
+    waypoint_marker->set_id(i+1);
+    waypoint_marker->set_action(ignition::msgs::Marker::ADD_MODIFY);
+    waypoint_marker->set_type(ignition::msgs::Marker::SPHERE);
+    waypoint_marker->set_visibility(ignition::msgs::Marker::GUI);
+    ignition::msgs::Set(waypoint_marker->mutable_scale(),
+      ignition::math::Vector3d(1.5, 1.5, 1.5));
+    ignition::msgs::Set(
+      waypoint_marker->mutable_material()->mutable_ambient(),
+      waypoint_color);
+    ignition::msgs::Set(
+      waypoint_marker->mutable_material()->mutable_diffuse(),
+      waypoint_color);
+    ignition::msgs::Set(waypoint_marker->mutable_pose(),
+      ignition::math::Pose3d(loc.x, loc.y, elevation, 0, 0, 0));
+
+    Eigen::Vector2d dir(cos(loc.yaw), sin(loc.yaw));
+    double length = 2.0;
+    ignition::msgs::Set(marker_headings->add_point(),
+      ignition::math::Vector3d(loc.x, loc.y, elevation));
+    ignition::msgs::Set(marker_headings->add_point(),
+      ignition::math::Vector3d(loc.x + length * dir.x(),
+      loc.y + length * dir.y(),
+      elevation));
+  }
+
+  _ign_node.Request(
+    "/marker_array", _trajectory_marker_msg, 5000, res, result);
+}
+
+void SlotcarPlugin::draw_lookahead_marker()
+{
+  auto pursuit_state = dataPtr->get_pursuit_state();
 
   // Lookahead point
   ignition::msgs::Marker marker_msg;
@@ -330,7 +421,7 @@ void SlotcarPlugin::draw_markers()
       pursuit_state.lookahead_point(1),
       pursuit_state.lookahead_point(2),
       0, 0, 0));
-  const double scale = 2.0;
+  const double scale = 1.5;
   ignition::msgs::Set(marker_msg.mutable_scale(),
     ignition::math::Vector3d(scale, scale, scale));
   ignition::msgs::Set(marker_msg.mutable_material()->mutable_ambient(),
@@ -338,59 +429,6 @@ void SlotcarPlugin::draw_markers()
   ignition::msgs::Set(marker_msg.mutable_material()->mutable_diffuse(),
     ignition::math::Color(0, 0, 1, 1));
   _ign_node.Request("/marker", marker_msg);
-
-  // Waypoints and lines between them
-  ignition::msgs::Marker line_marker;
-  line_marker.set_ns(dataPtr->model_name() + "_line");
-  line_marker.set_id(1);
-  line_marker.set_action(ignition::msgs::Marker::ADD_MODIFY);
-  line_marker.set_type(ignition::msgs::Marker::LINE_STRIP);
-  line_marker.set_visibility(ignition::msgs::Marker::GUI);
-  line_marker.mutable_lifetime()->set_sec(1);
-  ignition::msgs::Set(
-    line_marker.mutable_material()->mutable_ambient(),
-    ignition::math::Color(1, 0, 0, 1));
-  ignition::msgs::Set(
-    line_marker.mutable_material()->mutable_diffuse(),
-    ignition::math::Color(1, 0, 0, 1));
-
-  for (size_t i = 0; i < trajectory.size(); ++i)
-  {
-    auto wp = trajectory.at(i);
-    auto loc = wp.pose.translation();
-
-    // Add points to the trajectory line, slightly elevated for visibility.
-    ignition::msgs::Set(line_marker.add_point(),
-      ignition::math::Vector3d(loc.x(), loc.y(), 0.5)
-    );
-
-    // Draw green markers for waypoints that have been reached, otherwise red.
-    ignition::math::Color waypoint_color(0.0, 1.0, 0.0, 1.0);
-    if (i >= traj_wp_idx)
-    {
-      waypoint_color.Set(1.0, 0.0, 0.0, 1.0);
-    }
-    ignition::msgs::Marker waypoint_marker;
-    waypoint_marker.set_ns(dataPtr->model_name() + "_waypoints");
-    waypoint_marker.set_id(i+1);
-    waypoint_marker.set_action(ignition::msgs::Marker::ADD_MODIFY);
-    waypoint_marker.set_type(ignition::msgs::Marker::SPHERE);
-    waypoint_marker.set_visibility(ignition::msgs::Marker::GUI);
-    waypoint_marker.mutable_lifetime()->set_sec(1);
-    ignition::msgs::Set(waypoint_marker.mutable_scale(),
-      ignition::math::Vector3d(1.5, 1.5, 1.5));
-    ignition::msgs::Set(
-      waypoint_marker.mutable_material()->mutable_ambient(),
-      waypoint_color);
-    ignition::msgs::Set(
-      waypoint_marker.mutable_material()->mutable_diffuse(),
-      waypoint_color);
-    ignition::msgs::Set(waypoint_marker.mutable_pose(),
-      ignition::math::eigen3::convert(wp.pose)
-    );
-    _ign_node.Request("/marker", waypoint_marker);
-  }
-  _ign_node.Request("/marker", line_marker);
 }
 
 void SlotcarPlugin::PreUpdate(const UpdateInfo& info,
@@ -467,7 +505,7 @@ void SlotcarPlugin::PreUpdate(const UpdateInfo& info,
 
   if (dataPtr->display_markers)
   {
-    draw_markers();
+    draw_lookahead_marker();
   }
 }
 

--- a/rmf_robot_sim_ignition_plugins/src/slotcar.cpp
+++ b/rmf_robot_sim_ignition_plugins/src/slotcar.cpp
@@ -332,9 +332,7 @@ void SlotcarPlugin::path_request_marker_update(
   }
   _ign_node.Request(
     "/marker_array", _trajectory_marker_msg, 5000, res, result);
-
-  // _trajectory_marker_msg.clear_marker();
-
+  _trajectory_marker_msg.clear_marker();
   auto line_marker = _trajectory_marker_msg.add_marker();
   line_marker->set_ns(dataPtr->model_name() + "_line");
   line_marker->set_id(1);
@@ -394,9 +392,9 @@ void SlotcarPlugin::path_request_marker_update(
     ignition::msgs::Set(marker_headings->add_point(),
       ignition::math::Vector3d(loc.x, loc.y, elevation));
     ignition::msgs::Set(marker_headings->add_point(),
-      ignition::math::Vector3d(loc.x + length * dir.x(),
+      ignition::math::Vector3d(loc.x + length * dir.x(), 
       loc.y + length * dir.y(),
-      elevation));
+      elevation+0.5));
   }
 
   _ign_node.Request(

--- a/rmf_robot_sim_ignition_plugins/src/slotcar.cpp
+++ b/rmf_robot_sim_ignition_plugins/src/slotcar.cpp
@@ -403,7 +403,7 @@ void SlotcarPlugin::path_request_marker_update(
 
 void SlotcarPlugin::draw_lookahead_marker()
 {
-  auto pursuit_state = dataPtr->get_pursuit_state();
+  auto lookahead_point = dataPtr->get_lookahead_point();
 
   // Lookahead point
   ignition::msgs::Marker marker_msg;
@@ -415,9 +415,9 @@ void SlotcarPlugin::draw_lookahead_marker()
 
   ignition::msgs::Set(marker_msg.mutable_pose(),
     ignition::math::Pose3d(
-      pursuit_state.lookahead_point(0),
-      pursuit_state.lookahead_point(1),
-      pursuit_state.lookahead_point(2),
+      lookahead_point(0),
+      lookahead_point(1),
+      lookahead_point(2),
       0, 0, 0));
   const double scale = 1.5;
   ignition::msgs::Set(marker_msg.mutable_scale(),

--- a/rmf_robot_sim_ignition_plugins/src/slotcar.cpp
+++ b/rmf_robot_sim_ignition_plugins/src/slotcar.cpp
@@ -71,7 +71,8 @@ private:
     const std::pair<double, double>& displacements,
     const std::unordered_set<Entity> payloads,
     const double dt,
-    const double target_linear_velocity,
+    const double target_linear_speed_now,
+    const double target_linear_speed_destination,
     const std::optional<double>& max_linear_velocity);
   void init_infrastructure(EntityComponentManager& ecm);
   void item_dispensed_cb(const ignition::msgs::UInt64_V& msg);
@@ -163,7 +164,8 @@ void SlotcarPlugin::send_control_signals(EntityComponentManager& ecm,
   const std::pair<double, double>& displacements,
   const std::unordered_set<Entity> payloads,
   const double dt,
-  const double target_linear_velocity,
+  const double target_linear_speed_now,
+  const double target_linear_speed_destination,
   const std::optional<double>& max_linear_velocity)
 {
   auto lin_vel_cmd =
@@ -176,7 +178,8 @@ void SlotcarPlugin::send_control_signals(EntityComponentManager& ecm,
   double w_robot = _prev_w_command;
   std::array<double, 2> target_vels;
   target_vels = dataPtr->calculate_control_signals({v_robot, w_robot},
-      displacements, dt, target_linear_velocity, max_linear_velocity);
+      displacements, dt, target_linear_speed_now,
+      target_linear_speed_destination, max_linear_velocity);
 
   lin_vel_cmd->Data()[0] = target_vels[0];
   ang_vel_cmd->Data()[2] = target_vels[1];
@@ -458,7 +461,9 @@ void SlotcarPlugin::PreUpdate(const UpdateInfo& info,
       obstacle_positions, time);
 
   send_control_signals(ecm, {update_result.v, update_result.w}, _payloads, dt,
-    update_result.speed, update_result.max_speed);
+    update_result.target_linear_speed_now,
+    update_result.target_linear_speed_destination,
+    update_result.max_speed);
 
   if (dataPtr->display_markers)
   {


### PR DESCRIPTION
### Pure pursuit controller

Controller for the Ackermann steering slotcar to follow a path by driving towards the point one lookahead distance L away. 
The path is formed by the straight lines between waypoints. The target point is found by finding the intersections of the circle with radius L centred on the slotcar, and the path.

Adds markers in Ignition for visualisation of waypoints and lookahead points which is toggled using display_markers.

Updates `compute_desired_rate_of_change`. The target linear/angular speed while travelling as well as at the destination can be set.