### PR TITLE
Ignition GUI plugin to toggle floor visibility.

### DIFF
--- a/rmf_building_sim_ignition_plugins/CMakeLists.txt
+++ b/rmf_building_sim_ignition_plugins/CMakeLists.txt
@@ -37,9 +37,13 @@ ign_find_package(ignition-msgs8 REQUIRED)
 set(IGN_MSGS_VER 8)
 ign_find_package(ignition-transport11 REQUIRED)
 set(IGN_TRANSPORT_VER 11)
+ign_find_package(ignition-rendering6 REQUIRED)
+set(IGN_RENDERING_VER 6)
 ign_find_package(sdformat12 REQUIRED)
 
+
 find_package(rmf_building_sim_common REQUIRED)
+find_package(rmf_fleet_msgs REQUIRED)
 find_package (Qt5
   COMPONENTS
     Core
@@ -146,11 +150,41 @@ target_include_directories(toggle_charging
 )
 
 ###############################
+# toggle floors
+###############################
+
+QT5_ADD_RESOURCES(resources_RCC src/toggle_floors/toggle_floors.qrc)
+
+add_library(toggle_floors SHARED ${headers_MOC}
+  src/toggle_floors/toggle_floors.cpp
+  ${resources_RCC}
+)
+
+ament_target_dependencies(toggle_floors
+  ignition-gazebo${IGN_GAZEBO_VER}
+  ignition-plugin${IGN_PLUGIN_VER}
+  ignition-gui${IGN_GUI_VER}
+  ignition-rendering${IGN_RENDERING_VER}
+  Qt5Core
+  Qt5Qml
+  Qt5Quick
+  rclcpp
+  rmf_fleet_msgs
+)
+
+target_include_directories(toggle_floors
+  PUBLIC
+  ${Qt5Core_INCLUDE_DIRS}
+  ${Qt5Qml_INCLUDE_DIRS}
+  ${Qt5Quick_INCLUDE_DIRS}
+)
+
+###############################
 # install stuff
 ###############################
 
 install(
-  TARGETS door lift crowd_simulator toggle_charging
+  TARGETS door lift crowd_simulator toggle_charging toggle_floors
   LIBRARY DESTINATION lib/${PROJECT_NAME}
   ARCHIVE DESTINATION lib/${PROJECT_NAME}
 )

--- a/rmf_building_sim_ignition_plugins/CMakeLists.txt
+++ b/rmf_building_sim_ignition_plugins/CMakeLists.txt
@@ -162,9 +162,11 @@ add_library(toggle_floors SHARED ${headers_MOC}
 
 ament_target_dependencies(toggle_floors
   ignition-gazebo${IGN_GAZEBO_VER}
-  ignition-plugin${IGN_PLUGIN_VER}
   ignition-gui${IGN_GUI_VER}
+  ignition-msgs${IGN_MSGS_VER}
+  ignition-plugin${IGN_PLUGIN_VER}
   ignition-rendering${IGN_RENDERING_VER}
+  ignition-transport${IGN_TRANSPORT_VER}
   Qt5Core
   Qt5Qml
   Qt5Quick

--- a/rmf_building_sim_ignition_plugins/package.xml
+++ b/rmf_building_sim_ignition_plugins/package.xml
@@ -15,6 +15,7 @@
 
   <depend>rclcpp</depend>
   <depend>rmf_building_sim_common</depend>
+  <depend>rmf_fleet_msgs</depend>
   <depend>libqt5-core</depend>
   <depend>libqt5-qml</depend>
   <depend>libqt5-quick</depend>

--- a/rmf_building_sim_ignition_plugins/src/toggle_floors/toggle_floors.config
+++ b/rmf_building_sim_ignition_plugins/src/toggle_floors/toggle_floors.config
@@ -1,0 +1,3 @@
+<plugin filename="toggle_floors">
+  <title>Toggle Floors</title>
+</plugin>

--- a/rmf_building_sim_ignition_plugins/src/toggle_floors/toggle_floors.cpp
+++ b/rmf_building_sim_ignition_plugins/src/toggle_floors/toggle_floors.cpp
@@ -162,6 +162,7 @@ void toggle_floors::LoadConfig(const tinyxml2::XMLElement* _pluginElem)
           model_name.c_str());
       }
       _floor_visibility[floor_name] = true;
+      _floor_changed_flags[floor_name] = true;
       _floor_models[floor_name] = models;
     }
   }

--- a/rmf_building_sim_ignition_plugins/src/toggle_floors/toggle_floors.cpp
+++ b/rmf_building_sim_ignition_plugins/src/toggle_floors/toggle_floors.cpp
@@ -95,7 +95,6 @@ toggle_floors::~toggle_floors()
 void toggle_floors::get_plugin_config()
 {
   ignition::transport::Node node;
-  bool executed{false};
   bool result{false};
   unsigned int timeout{2000};
   const std::string WORLD_NAME = "sim_world";
@@ -104,7 +103,7 @@ void toggle_floors::get_plugin_config()
   std::string service = ignition::transport::TopicUtils::AsValidTopic("/world/" + WORLD_NAME +
       "/gui/info");
 
-  executed = node.Request(service, timeout, res, result);
+  node.Request(service, timeout, res, result);
 
   for (int p = 0; p < res.plugin_size(); ++p)
   {
@@ -112,10 +111,7 @@ void toggle_floors::get_plugin_config()
     const auto& fileName = plugin.filename();
     if (fileName == "toggle_floors")
     {
-      std::string pluginStr = "<plugin filename='" + fileName + "'>" +
-        plugin.innerxml() + "</plugin>";
-
-      _config_xml.Parse(pluginStr.c_str());
+      _config_xml.Parse(plugin.innerxml().c_str());
       break;
     }
   }
@@ -131,19 +127,19 @@ void toggle_floors::LoadConfig(const tinyxml2::XMLElement* _pluginElem)
     {
       if (_pluginElem->FirstChildElement("floor"))
       {
-        return _pluginElem;
+        return _pluginElem->FirstChildElement("floor");
       }
       else
       {
         get_plugin_config();
-        const tinyxml2::XMLElement* p = _config_xml.FirstChildElement("plugin");
+        const tinyxml2::XMLElement* p = _config_xml.RootElement();
         return p;
       }
     } ();
 
   if (plugin_config)
   {
-    for (auto floor_ele = plugin_config->FirstChildElement("floor");
+    for (auto floor_ele = plugin_config->ToElement();
       floor_ele;
       floor_ele = floor_ele->NextSiblingElement("floor"))
     {

--- a/rmf_building_sim_ignition_plugins/src/toggle_floors/toggle_floors.cpp
+++ b/rmf_building_sim_ignition_plugins/src/toggle_floors/toggle_floors.cpp
@@ -1,0 +1,218 @@
+/*
+ * Copyright (C) 2020 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+#include <string>
+#include <iostream>
+
+#include <ignition/gui/Application.hh>
+#include <ignition/gui/GuiEvents.hh>
+#include <ignition/gui/MainWindow.hh>
+#include <ignition/gui/qt.h>
+#include <ignition/gui/Plugin.hh>
+
+#include <ignition/plugin/Register.hh>
+
+#include <ignition/rendering/RenderEngine.hh>
+#include <ignition/rendering/RenderingIface.hh>
+#include <ignition/rendering/Scene.hh>
+
+#include <rclcpp/rclcpp.hpp>
+#include <rmf_fleet_msgs/msg/fleet_state.hpp>
+#include <rmf_fleet_msgs/msg/robot_state.hpp>
+
+using FleetState = rmf_fleet_msgs::msg::FleetState;
+using RobotState = rmf_fleet_msgs::msg::RobotState;
+
+class toggle_floors
+  :
+  public ignition::gui::Plugin
+{
+  Q_OBJECT
+
+public:
+  toggle_floors();
+  ~toggle_floors();
+  void LoadConfig(const tinyxml2::XMLElement* _pluginElem) override;
+
+private:
+
+  rclcpp::Node::SharedPtr _ros_node;
+  rclcpp::Subscription<FleetState>::SharedPtr _fleet_state_sub;
+
+  bool eventFilter(QObject* _obj, QEvent* _event) override;
+  void PerformRenderingOperations();
+  void FindScene();
+  ignition::rendering::ScenePtr scene{nullptr};
+  QStringList qfloors;
+  std::unordered_map<std::string, std::atomic<bool>> _floor_changed_flags;
+  std::unordered_map<std::string, std::atomic<bool>> _floor_visibility;
+  std::unordered_map<std::string, std::string> _robot_floor;
+  std::unordered_map<std::string, std::vector<std::string>> _floor_models;
+
+  bool _floor_checked_flag{false};
+
+
+protected slots:
+  void OnFloorChecked(const QString, bool);
+
+};
+
+toggle_floors::toggle_floors()
+{
+  char const** argv = NULL;
+  if (!rclcpp::ok())
+  {
+    rclcpp::init(0, argv);
+  }
+  _ros_node = std::make_shared<rclcpp::Node>("toggle_floors");
+}
+
+toggle_floors::~toggle_floors()
+{
+  ignition::gui::App()->findChild<
+    ignition::gui::MainWindow*>()->removeEventFilter(this);
+}
+
+void toggle_floors::LoadConfig(const tinyxml2::XMLElement* _pluginElem)
+{
+  if (!_pluginElem)
+    return;
+
+  if (this->title.empty())
+    this->title = "Toggle Floors";
+
+  if (_pluginElem)
+  {
+    for (auto floor_ele = _pluginElem->FirstChildElement("floor");
+      floor_ele;
+      floor_ele = floor_ele->NextSiblingElement("floor"))
+    {
+      std::vector<std::string> models;
+
+      auto floor_name = std::string(floor_ele->Attribute("name"));
+      auto building = std::string(floor_ele->Attribute("model_name"));
+      qfloors.append(QString::fromStdString(floor_name));
+      models.push_back(building);
+
+      for (auto model_ele = floor_ele->FirstChildElement("model");
+        model_ele;
+        model_ele = model_ele->NextSiblingElement("model"))
+      {
+        auto model_name = std::string(model_ele->Attribute("name"));
+        models.push_back(model_name);
+        printf(
+          "toggle_floors found a floor element: [%s]->[%s]\n",
+          floor_name.c_str(),
+          model_name.c_str());
+      }
+      _floor_visibility[floor_name] = true;
+      _floor_models[floor_name] = models;
+    }
+  }
+
+  auto qos_profile = rclcpp::QoS(10);
+  _fleet_state_sub = _ros_node->create_subscription<FleetState>(
+    "/fleet_states", qos_profile,
+    [this](FleetState::UniquePtr msg)
+    {
+      for (const RobotState& robot : msg->robots)
+      {
+        _robot_floor[robot.name] = robot.location.level_name;
+      }
+    });
+
+  this->Context()->setContextProperty("qfloors", qfloors);
+  ignition::gui::App()->findChild<
+    ignition::gui::MainWindow*>()->installEventFilter(this);
+}
+
+void toggle_floors::OnFloorChecked(const QString floor, bool checked)
+{
+  auto floor_str = floor.toStdString();
+  _floor_visibility[floor_str] = checked;
+  _floor_changed_flags[floor_str] = true;
+}
+
+void toggle_floors::PerformRenderingOperations()
+{
+  if (nullptr == this->scene)
+  {
+    this->FindScene();
+  }
+  if (nullptr == this->scene)
+  {
+    return;
+  }
+
+  rclcpp::spin_some(_ros_node);
+
+  for (auto& flags_itr : _floor_changed_flags)
+  {
+    if (flags_itr.second)
+    {
+      auto floor_name = flags_itr.first;
+      auto models = _floor_models[floor_name];
+      for (const std::string& model : models)
+      {
+        auto target_node = this->scene->NodeByName(model);
+        auto target_vis =
+          std::dynamic_pointer_cast<ignition::rendering::Visual>(target_node);
+        target_vis->SetVisible(_floor_visibility[floor_name]);
+      }
+      flags_itr.second = false;
+    }
+  }
+
+  for (auto& robots_itr : _robot_floor)
+  {
+    auto target_node = this->scene->NodeByName(robots_itr.first);
+    auto target_vis = std::dynamic_pointer_cast<ignition::rendering::Visual>(
+      target_node);
+    target_vis->SetVisible(_floor_visibility[robots_itr.second]);
+  }
+}
+
+void toggle_floors::FindScene()
+{
+  auto loadedEngNames = ignition::rendering::loadedEngines();
+  auto engineName = loadedEngNames[0];
+  auto engine = ignition::rendering::engine(engineName);
+
+  auto scenePtr = engine->SceneByIndex(0);
+  if (!scenePtr->IsInitialized() || nullptr == scenePtr->RootVisual())
+  {
+    return;
+  }
+  this->scene = scenePtr;
+}
+
+bool toggle_floors::eventFilter(QObject* _obj, QEvent* _event)
+{
+  if (_event->type() == ignition::gui::events::Render::kType)
+  {
+    this->PerformRenderingOperations();
+  }
+  return QObject::eventFilter(_obj, _event);
+}
+
+// Register this plugin
+IGNITION_ADD_PLUGIN(toggle_floors,
+  ignition::gui::Plugin
+)
+
+
+#include "toggle_floors.moc"

--- a/rmf_building_sim_ignition_plugins/src/toggle_floors/toggle_floors.qml
+++ b/rmf_building_sim_ignition_plugins/src/toggle_floors/toggle_floors.qml
@@ -25,53 +25,31 @@ import QtQuick.Controls.Styles 1.4
 
 ToolBar {
   Layout.minimumWidth: 280
-  Layout.minimumHeight: 200
+  Layout.minimumHeight: 370
 
   background: Rectangle {
     color: "transparent"
   }
 
-  ButtonGroup {
-    id: group
-  }
-
   GridLayout {
+    id: gridfloors
     anchors.fill: parent
     columns: 1
-    rows: 3
+    rows: 6
     columnSpacing: 5
-    CheckBox {
-      text: qsTr("Allow Charging")
-      Layout.columnSpan: 1
-      Layout.alignment: Qt.AlignVCenter | Qt.AlignLeft
-      Layout.leftMargin: 2
-      checked: true
-      onClicked: {
-        toggle_charging.OnEnableCharge(checked)
+    Repeater {
+      model: qfloors
+      CheckBox {
+        text: modelData
+        Layout.columnSpan: 1
+        Layout.alignment: Qt.AlignVCenter | Qt.AlignLeft
+        Layout.leftMargin: 2
+        checked: true
+        onClicked: {
+          toggle_floors.OnFloorChecked(text, checked)
+        }
       }
-    }
 
-    CheckBox {
-      text: qsTr("Instant Charging")
-      Layout.columnSpan: 1
-      Layout.alignment: Qt.AlignVCenter | Qt.AlignLeft
-      Layout.leftMargin: 2
-      checked: false
-      onClicked: {
-        toggle_charging.OnEnableInstantCharge(checked)
-      }
     }
-
-    CheckBox {
-      text: qsTr("Allow Battery Drain")
-      Layout.columnSpan: 1
-      Layout.alignment: Qt.AlignVCenter | Qt.AlignLeft
-      Layout.leftMargin: 2
-      checked: true
-      onClicked: {
-        toggle_charging.OnEnableDrain(checked)
-      }
-    }
-
   }
 }

--- a/rmf_building_sim_ignition_plugins/src/toggle_floors/toggle_floors.qrc
+++ b/rmf_building_sim_ignition_plugins/src/toggle_floors/toggle_floors.qrc
@@ -1,0 +1,5 @@
+<!DOCTYPE RCC><RCC version="1.0">
+  <qresource prefix="toggle_floors/">
+    <file>toggle_floors.qml</file>
+  </qresource>
+</RCC>


### PR DESCRIPTION
Signed-off-by: Tan Chian Fern <chianfern@openrobotics.org>

### toggle_floors plugin 
Adds a `ignition::gui::Plugin` to toggle visibility of floors and robots. 
Requires [rmf_traffic_editor #424](https://github.com/open-rmf/rmf_traffic_editor/pull/424). Closes #66. 

Note: There's an unresolved issue with `LoadConfig()`. It reads the information in the world sdf correctly on first load, but not when the plugin is closed and reloaded. 
Update: Resolved, plugin information is retrieved again when reloaded.