### PR TITLE
Fixes a segfault in toggle floor plugin which causes ignition to crash when scene is not ready.

### DIFF
--- a/rmf_building_sim_ignition_plugins/src/toggle_floors/toggle_floors.cpp
+++ b/rmf_building_sim_ignition_plugins/src/toggle_floors/toggle_floors.cpp
@@ -212,6 +212,11 @@ void toggle_floors::PerformRenderingOperations()
       for (const std::string& model : models)
       {
         auto target_node = this->scene->NodeByName(model);
+        if (target_node == NULL)
+        {
+          ignwarn << "Node for " << model << "was not found" <<std::endl;
+          continue;
+        }
         auto target_vis =
           std::dynamic_pointer_cast<ignition::rendering::Visual>(target_node);
         target_vis->SetVisible(_floor_visibility[floor_name]);


### PR DESCRIPTION
This PR fixes a segfault I have been experiencing when loading large worlds. Often the rendering scene is not fully setup causing the` this->scene->NodeByName` to crash. This PR pushes a simple fix to skip over scenarios where the scene has not yet loaded the model.

Signed-off-by: Arjo Chakravarty <arjo@openrobotics.org>