### PR TITLE
Fixes potential segfault

### DIFF
--- a/rmf_building_sim_ignition_plugins/src/toggle_floors/toggle_floors.cpp
+++ b/rmf_building_sim_ignition_plugins/src/toggle_floors/toggle_floors.cpp
@@ -228,6 +228,11 @@ void toggle_floors::PerformRenderingOperations()
   for (auto& robots_itr : _robot_floor)
   {
     auto target_node = this->scene->NodeByName(robots_itr.first);
+    if (target_node == NULL)
+    {
+      ignwarn << "Node for " << model << "was not found" <<std::endl;
+      continue;
+    }
     auto target_vis = std::dynamic_pointer_cast<ignition::rendering::Visual>(
       target_node);
     target_vis->SetVisible(_floor_visibility[robots_itr.second]);


### PR DESCRIPTION
The fix is similar in nature to #78. Just noticed another place where we are not checking for a potential null return value. This hasn't segfaulted for me yet but theres no reason why it would not.

Signed-off-by: Arjo Chakravarty <arjo@openrobotics.org>