### PR TITLE
Fixes #75 by using ignition ecm instead of traversing sdformat parents

### DIFF
--- a/rmf_building_sim_common/include/rmf_building_sim_common/door_common.hpp
+++ b/rmf_building_sim_common/include/rmf_building_sim_common/door_common.hpp
@@ -72,7 +72,6 @@ public:
   std::vector<DoorUpdateResult> update(const double time,
     const std::vector<DoorUpdateRequest>& request);
 
-private:
 
   struct DoorElement
   {
@@ -106,6 +105,14 @@ private:
   // Map joint name to its DoorElement
   using Doors = std::unordered_map<std::string, DoorElement>;
 
+  template<typename SdfPtrT>
+  static std::shared_ptr<DoorCommon> make(
+    const std::string& door_name,
+    rclcpp::Node::SharedPtr node,
+    SdfPtrT& sdf,
+    Doors& doors);
+
+private:
   DoorMode requested_mode() const;
 
   void publish_state(const uint32_t door_value, const rclcpp::Time& time);
@@ -258,6 +265,33 @@ std::shared_ptr<DoorCommon> DoorCommon::make(
 
   return door_common;
 
+}
+
+template<typename SdfPtrT>
+std::shared_ptr<DoorCommon> DoorCommon::make(
+  const std::string& door_name,
+  rclcpp::Node::SharedPtr node,
+  SdfPtrT& sdf,
+  Doors& doors)
+{
+  // We work with a clone to avoid const correctness issues with
+  // get_sdf_param functions in utils.hpp
+  auto sdf_clone = sdf->Clone();
+
+  MotionParams params;
+  get_sdf_param_if_available<double>(sdf_clone, "v_max_door", params.v_max);
+  get_sdf_param_if_available<double>(sdf_clone, "a_max_door", params.a_max);
+  get_sdf_param_if_available<double>(sdf_clone, "a_nom_door", params.a_nom);
+  get_sdf_param_if_available<double>(sdf_clone, "dx_min_door", params.dx_min);
+  get_sdf_param_if_available<double>(sdf_clone, "f_max_door", params.f_max);
+
+  std::shared_ptr<DoorCommon> door_common(new DoorCommon(
+      door_name,
+      node,
+      params,
+      doors));
+
+  return door_common;
 }
 
 } // namespace rmf_building_sim_common

--- a/rmf_building_sim_ignition_plugins/src/door.cpp
+++ b/rmf_building_sim_ignition_plugins/src/door.cpp
@@ -81,9 +81,11 @@ private:
     }
 
     std::unordered_set<std::string> joint_names;
-    if (!left_door_joint_name.empty() && left_door_joint_name != "empty_joint")
+    if (!left_door_joint_name.empty()
+      && left_door_joint_name != "empty_joint")
       joint_names.insert(left_door_joint_name);
-    if (!right_door_joint_name.empty() && right_door_joint_name != "empty_joint")
+    if (!right_door_joint_name.empty()
+      && right_door_joint_name != "empty_joint")
       joint_names.insert(right_door_joint_name);
 
     DoorCommon::Doors doors;

--- a/rmf_building_sim_ignition_plugins/src/door.cpp
+++ b/rmf_building_sim_ignition_plugins/src/door.cpp
@@ -3,6 +3,7 @@
 #include <ignition/gazebo/System.hh>
 #include <ignition/gazebo/Model.hh>
 #include <ignition/gazebo/Util.hh>
+#include <ignition/gazebo/components/JointAxis.hh>
 #include <ignition/gazebo/components/JointPosition.hh>
 #include <ignition/gazebo/components/JointVelocity.hh>
 #include <ignition/gazebo/components/JointVelocityCmd.hh>
@@ -41,6 +42,79 @@ private:
     enableComponent<components::JointVelocityCmd>(ecm, entity);
   }
 
+  std::optional<DoorCommon::Doors> get_doors(
+    Model& model,
+    const std::string& door_name,
+    const std::shared_ptr<const sdf::Element>& sdf,
+    EntityComponentManager& ecm)
+  {
+    // We work with a clone to avoid const correctness issues with
+    // get_sdf_param functions in utils.hpp
+    auto sdf_clone = sdf->Clone();
+    std::string left_door_joint_name;
+    std::string right_door_joint_name;
+    std::string door_type;
+
+    auto door_element = sdf_clone;
+    if (!get_element_required(sdf_clone, "door", door_element) ||
+      !get_sdf_attribute_required<std::string>(
+        door_element, "left_joint_name", left_door_joint_name) ||
+      !get_sdf_attribute_required<std::string>(
+        door_element, "right_joint_name", right_door_joint_name) ||
+      !get_sdf_attribute_required<std::string>(
+        door_element, "type", door_type))
+    {
+      RCLCPP_ERROR(_ros_node->get_logger(),
+        " -- Missing required parameters for [%s] plugin",
+        door_name.c_str());
+      return std::nullopt;
+    }
+
+    if ((left_door_joint_name == "empty_joint" &&
+      right_door_joint_name == "empty_joint") ||
+      (left_door_joint_name.empty() && right_door_joint_name.empty()))
+    {
+      RCLCPP_ERROR(_ros_node->get_logger(),
+        " -- Both door joint names are missing for [%s] plugin, at least one"
+        " is required", door_name.c_str());
+      return std::nullopt;
+    }
+
+    std::unordered_set<std::string> joint_names;
+    if (!left_door_joint_name.empty() && left_door_joint_name != "empty_joint")
+      joint_names.insert(left_door_joint_name);
+    if (!right_door_joint_name.empty() && right_door_joint_name != "empty_joint")
+      joint_names.insert(right_door_joint_name);
+
+    DoorCommon::Doors doors;
+    for (auto joint_name: joint_names)
+    {
+      auto joint_entity = model.JointByName(ecm, joint_name);
+      if (joint_entity == kNullEntity)
+      {
+        continue;
+      }
+      const auto *joint_axis =
+        ecm.Component<components::JointAxis>(joint_entity);
+
+      double lower_limit = -1.57;
+      double upper_limit = 0.0;
+      if(joint_axis != nullptr)
+      {
+        lower_limit = joint_axis->Data().Lower();
+        upper_limit = joint_axis->Data().Upper();
+      }
+
+      DoorCommon::DoorElement door_element;
+      if (joint_name == right_door_joint_name)
+        door_element =
+          DoorCommon::DoorElement{lower_limit, upper_limit, true};
+      else if (joint_name == left_door_joint_name)
+        door_element = DoorCommon::DoorElement{lower_limit, upper_limit};
+      doors.insert({joint_name, door_element});
+    }
+    return doors;
+  }
 public:
   DoorPlugin()
   {
@@ -65,10 +139,16 @@ public:
       "Loading DoorPlugin for [%s]",
       name.c_str());
 
+    auto doors = get_doors(model, name, sdf, ecm);
+
+    if (!doors.has_value())
+      return;
+
     _door_common = DoorCommon::make(
       name,
       _ros_node,
-      sdf);
+      sdf,
+      doors.value());
 
     if (!_door_common)
       return;


### PR DESCRIPTION
This PR addresses issue #75. @luca-della-vedova has found an alternative two liner fix in upstream sdformat that would solve our problems. However, to future proof the ignition version of the plugin we should try to use the ecm to retrieve properties instead of relying on sdformat for traversing the joint properties.

Signed-off-by: Arjo Chakravarty <arjo@openrobotics.org>