### PR TITLE
Sanitize node names to avoid plugin exceptions

### DIFF
--- a/rmf_building_sim_common/include/rmf_building_sim_common/utils.hpp
+++ b/rmf_building_sim_common/include/rmf_building_sim_common/utils.hpp
@@ -34,6 +34,9 @@ double compute_desired_rate_of_change(
   const double _dt);
 
 //==============================================================================
+void sanitize_node_name(std::string& node_name);
+
+//==============================================================================
 template<typename SdfPtrT, typename SdfElementPtrT>
 bool get_element_required(
   SdfPtrT& _sdf,

--- a/rmf_building_sim_common/src/utils.cpp
+++ b/rmf_building_sim_common/src/utils.cpp
@@ -1,3 +1,4 @@
+#include <cctype>
 #include <cmath>
 #include <algorithm>
 
@@ -98,4 +99,20 @@ double compute_desired_rate_of_change(
   // Flip the sign to the correct direction before returning the value
   return sign * v_next;
 }
-} // namespace rmf_building_sim_common
+
+// ROS 2 nodes can only have alphanumeric characters and underscores, this
+// function removes special characters and replaces dashes / spaces with
+// underscores to avoid throwing exceptions.
+//==============================================================================
+void sanitize_node_name(std::string& node_name)
+{
+  std::replace(node_name.begin(), node_name.end(), ' ', '_');
+  std::replace(node_name.begin(), node_name.end(), '-', '_');
+  node_name.erase(std::remove_if(node_name.begin(), node_name.end(),
+    [](auto const& c) -> bool
+    {
+      return c != '_' && !std::isalnum(c);
+    }), node_name.end());
+}
+}
+// namespace rmf_building_sim_common

--- a/rmf_building_sim_gz_classic_plugins/src/door.cpp
+++ b/rmf_building_sim_gz_classic_plugins/src/door.cpp
@@ -32,7 +32,8 @@ public:
 
   void Load(gazebo::physics::ModelPtr model, sdf::ElementPtr sdf) override
   {
-    const std::string& node_name = model->GetName() + "_node";
+    std::string node_name = model->GetName() + "_node";
+    sanitize_node_name(node_name);
     auto _ros_node = gazebo_ros::Node::Get(sdf, node_name);
     _model = model;
 

--- a/rmf_building_sim_gz_classic_plugins/src/lift.cpp
+++ b/rmf_building_sim_gz_classic_plugins/src/lift.cpp
@@ -34,7 +34,8 @@ public:
 
   void Load(gazebo::physics::ModelPtr model, sdf::ElementPtr sdf) override
   {
-    const std::string& node_name = model->GetName() + "_node";
+    std::string node_name = model->GetName() + "_node";
+    sanitize_node_name(node_name);
     _ros_node = gazebo_ros::Node::Get(sdf, node_name);
     _model = model;
 

--- a/rmf_building_sim_gz_plugins/src/door.cpp
+++ b/rmf_building_sim_gz_plugins/src/door.cpp
@@ -146,6 +146,7 @@ public:
     if (!rclcpp::ok())
       rclcpp::init(0, argv);
     std::string plugin_name("plugin_" + name);
+    sanitize_node_name(plugin_name);
     _ros_node = std::make_shared<rclcpp::Node>(plugin_name);
 
     RCLCPP_INFO(_ros_node->get_logger(),

--- a/rmf_building_sim_gz_plugins/src/lift.cpp
+++ b/rmf_building_sim_gz_plugins/src/lift.cpp
@@ -142,6 +142,7 @@ public:
     if (!rclcpp::ok())
       rclcpp::init(0, argv);
     std::string plugin_name("plugin_" + model.Name(ecm));
+    sanitize_node_name(plugin_name);
     _ros_node = std::make_shared<rclcpp::Node>(plugin_name);
 
     RCLCPP_INFO(_ros_node->get_logger(),

--- a/rmf_robot_sim_common/include/rmf_robot_sim_common/utils.hpp
+++ b/rmf_robot_sim_common/include/rmf_robot_sim_common/utils.hpp
@@ -89,6 +89,8 @@ double compute_desired_rate_of_change(
 
 rclcpp::Time simulation_now(double t);
 
+void sanitize_node_name(std::string& node_name);
+
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 template<typename SdfPtrT, typename SdfElementPtrT>
 bool get_element_required(

--- a/rmf_robot_sim_common/src/utils.cpp
+++ b/rmf_robot_sim_common/src/utils.cpp
@@ -99,4 +99,19 @@ rclcpp::Time simulation_now(double t)
   return rclcpp::Time{t_sec, t_nsec, RCL_ROS_TIME};
 }
 
+// ROS 2 nodes can only have alphanumeric characters and underscores, this
+// function removes special characters and replaces dashes / spaces with
+// underscores to avoid throwing exceptions.
+//==============================================================================
+void sanitize_node_name(std::string& node_name)
+{
+  std::replace(node_name.begin(), node_name.end(), ' ', '_');
+  std::replace(node_name.begin(), node_name.end(), '-', '_');
+  node_name.erase(std::remove_if(node_name.begin(), node_name.end(),
+    [](auto const& c) -> bool
+    {
+      return c != '_' && !std::isalnum(c);
+    }), node_name.end());
+}
+
 } // namespace rmf_plugins_utils

--- a/rmf_robot_sim_gz_classic_plugins/src/slotcar.cpp
+++ b/rmf_robot_sim_gz_classic_plugins/src/slotcar.cpp
@@ -82,7 +82,8 @@ void SlotcarPlugin::Load(gazebo::physics::ModelPtr model, sdf::ElementPtr sdf)
   _model = model;
   dataPtr->set_model_name(_model->GetName());
   dataPtr->read_sdf(sdf);
-  const std::string& node_name = _model->GetName() + "_node";
+  std::string node_name = _model->GetName() + "_node";
+  rmf_plugins_utils::sanitize_node_name(node_name);
   gazebo_ros::Node::SharedPtr _ros_node = gazebo_ros::Node::Get(sdf, node_name);
   dataPtr->init_ros_node(_ros_node);
 

--- a/rmf_robot_sim_gz_plugins/src/slotcar.cpp
+++ b/rmf_robot_sim_gz_plugins/src/slotcar.cpp
@@ -120,6 +120,7 @@ void SlotcarPlugin::Configure(const Entity& entity,
   if (!rclcpp::ok())
     rclcpp::init(0, argv);
   std::string plugin_name("plugin_" + model_name);
+  rmf_plugins_utils::sanitize_node_name(plugin_name);
   _ros_node = std::make_shared<rclcpp::Node>(plugin_name);
   // TODO Check if executor is getting callbacks
   //executor = std::make_unique<rclcpp::executors::MultiThreadedExecutor>();


### PR DESCRIPTION
## Bug fix

### Fixed bug

Closes https://github.com/open-rmf/rmf_simulation/issues/109

### Fix applied

Add a function that sanitizes the node name before creating it by removing special characters and substituting spaces / dashes with underscores.
This is applied to all plugins that have a node name that is generated from user input, specifically lifts, doors and slotcar.