### PR TITLE
Add Noise to Slotcar Plugin

### DIFF
--- a/rmf_robot_sim_common/CMakeLists.txt
+++ b/rmf_robot_sim_common/CMakeLists.txt
@@ -16,17 +16,22 @@ if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   add_compile_options(-Wall -Wextra -Wpedantic)
 endif()
 
-find_package(eigen3_cmake_module REQUIRED)
-find_package(Eigen3 REQUIRED)
 find_package(ament_cmake REQUIRED)
-find_package(rclcpp REQUIRED)
+find_package(Eigen3 REQUIRED)
+find_package(eigen3_cmake_module REQUIRED)
 find_package(geometry_msgs REQUIRED)
+find_package(rclcpp REQUIRED)
+find_package(rmf_building_map_msgs REQUIRED)
+find_package(rmf_dispenser_msgs REQUIRED)
+find_package(rmf_fleet_msgs REQUIRED)
+find_package(rmf_ingestor_msgs REQUIRED)
 find_package(std_msgs REQUIRED)
 find_package(tf2_ros REQUIRED)
-find_package(rmf_fleet_msgs REQUIRED)
-find_package(rmf_dispenser_msgs REQUIRED)
-find_package(rmf_ingestor_msgs REQUIRED)
-find_package(rmf_building_map_msgs REQUIRED)
+
+find_package(ignition-cmake2 REQUIRED)
+ign_find_package(ignition-sensors6 REQUIRED)
+ign_find_package(ignition-common4 REQUIRED)
+ign_find_package(sdformat12 REQUIRED)
 
 include(GNUInstallDirs)
 
@@ -133,6 +138,7 @@ target_include_directories(readonly_common
 add_library(slotcar_common SHARED ${PROJECT_SOURCE_DIR}/src/slotcar_common.cpp)
 
 ament_target_dependencies(slotcar_common
+  PUBLIC
     Eigen3
     rmf_fleet_msgs
     rmf_building_map_msgs
@@ -147,10 +153,15 @@ target_include_directories(slotcar_common
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
     $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
     ${EIGEN3_INCLUDE_DIRS}
+    ${IGNITION-SENSORS_INCLUDE_DIRS}
+    ${IGNITION-COMMON_INCLUDE_DIRS}
 )
 
 target_link_libraries(slotcar_common
+  PUBLIC
     rmf_robot_sim_utils
+    #ignition-sensosr6::ignition-sensosr6
+    sdformat12::sdformat12
 )
 
 ###############################

--- a/rmf_robot_sim_common/include/rmf_robot_sim_common/slotcar_common.hpp
+++ b/rmf_robot_sim_common/include/rmf_robot_sim_common/slotcar_common.hpp
@@ -18,6 +18,7 @@
 #ifndef RMF_BUILDING_SIM_COMMON__SLOTCAR_COMMON_HPP
 #define RMF_BUILDING_SIM_COMMON__SLOTCAR_COMMON_HPP
 
+#include <optional>
 #include <sstream>
 
 #include <rclcpp/rclcpp.hpp>
@@ -31,6 +32,8 @@
 #include <rmf_fleet_msgs/msg/pause_request.hpp>
 #include <rmf_fleet_msgs/msg/mode_request.hpp>
 #include <rmf_building_map_msgs/msg/building_map.hpp>
+
+#include <ignition/sensors/Noise.hh>
 
 namespace rmf_robot_sim_common {
 
@@ -105,6 +108,20 @@ public:
 
   void publish_robot_state(const double time);
 
+  /// Add noise to the reported location
+  /// \param[in] noise to be applied
+  void set_translation_noise(ignition::sensors::NoisePtr noise);
+
+  /// Add noise to the reported orientation
+  /// \param[in] noise to be applied
+  void set_rotation_noise(ignition::sensors::NoisePtr noise);
+
+  /// Stop using translation noise
+  void unset_translation_noise();
+
+  /// Stop using rotation noise
+  void unset_rotation_noise();
+
   Eigen::Vector3d get_lookahead_point() const;
 
   bool display_markers = false; // Ignition only: toggles display of waypoint and lookahead markers
@@ -115,6 +132,12 @@ public:
   { _path_request_callback = cb; }
 
 private:
+  // Localization noise - Translation
+  std::optional<ignition::sensors::NoisePtr> _translation_noise;
+
+  // Localization noise - Rotation
+  std::optional<ignition::sensors::NoisePtr> _rotation_noise;
+
   // Parameters needed for power dissipation and charging calculations
   // Default values may be overriden using values from sdf file
   struct PowerParams
@@ -248,7 +271,7 @@ private:
 
   void publish_tf2(const rclcpp::Time& t);
 
-  void publish_state_topic(const rclcpp::Time& t);
+  void publish_state_topic(const rclcpp::Time& t, double dt);
 
   bool path_request_valid(
     const rmf_fleet_msgs::msg::PathRequest::SharedPtr msg);

--- a/rmf_robot_sim_gz_classic_plugins/CMakeLists.txt
+++ b/rmf_robot_sim_gz_classic_plugins/CMakeLists.txt
@@ -27,6 +27,8 @@ find_package(rmf_fleet_msgs REQUIRED)
 find_package(rmf_building_map_msgs REQUIRED)
 find_package(rmf_robot_sim_common REQUIRED)
 
+find_package(ignition-cmake2 REQUIRED)
+ign_find_package(sdformat12 REQUIRED)
 include(GNUInstallDirs)
 
 ###############################

--- a/rmf_robot_sim_gz_plugins/src/slotcar.cpp
+++ b/rmf_robot_sim_gz_plugins/src/slotcar.cpp
@@ -104,10 +104,12 @@ SlotcarPlugin::SlotcarPlugin()
   }
   // We do rest of initialization during ::Configure
 
-  if (!_ign_node.Subscribe("/slotcar/translation_noise", &SlotcarPlugin::translation_noise_cb,
+  if (!_ign_node.Subscribe("/slotcar/translation_noise",
+    &SlotcarPlugin::translation_noise_cb,
     this))
   {
-    std::cerr << "Error subscribing to topic [/slotcar/translation_noise]" << std::endl;
+    std::cerr << "Error subscribing to topic [/slotcar/translation_noise]" <<
+      std::endl;
   }
 }
 
@@ -122,18 +124,19 @@ void SlotcarPlugin::translation_noise_cb(const ignition::msgs::SensorNoise& msg)
   {
     dataPtr->unset_translation_noise();
   }
-  else 
+  else
   {
     sdf::Noise noise;
-    switch(msg.type()) {
+    switch (msg.type())
+    {
       case 2:
-      noise.SetType(sdf::NoiseType::GAUSSIAN);
-      break;
+        noise.SetType(sdf::NoiseType::GAUSSIAN);
+        break;
       case 3:
-      noise.SetType(sdf::NoiseType::GAUSSIAN_QUANTIZED);
-      break; 
+        noise.SetType(sdf::NoiseType::GAUSSIAN_QUANTIZED);
+        break;
       default:
-      return;
+        return;
     }
     noise.SetMean(msg.mean());
     noise.SetStdDev(msg.stddev());


### PR DESCRIPTION
## New feature implementation

### Implemented feature

This should help simulate real world scenarios where robots might report noisy location.

To use publish a gz.sim.SensorNoise message to `/slotcar/translation_noise`.

Note: This feature only works on GZ-SIM

