### PR TITLE
Fix door drift in simulation

### DIFF
--- a/rmf_building_sim_gz_plugins/include/rmf_building_sim_gz_plugins/components/Door.hpp
+++ b/rmf_building_sim_gz_plugins/include/rmf_building_sim_gz_plugins/components/Door.hpp
@@ -55,6 +55,10 @@ GZ_SIM_REGISTER_COMPONENT("rmf_components.Door", Door)
 /// \brief A component used to command an RMF door to open / close.
 using DoorCmd = Component<DoorModeCmp, class DoorCmdTag>;
 GZ_SIM_REGISTER_COMPONENT("rmf_components.DoorCmd", DoorCmd)
+
+/// \brief A component used to show the state of an RMF door.
+using DoorStateComp = Component<DoorModeCmp, class DoorStateTag>;
+GZ_SIM_REGISTER_COMPONENT("rmf_components.DoorStateComp", DoorStateComp)
 }
 }
 }

--- a/rmf_building_sim_gz_plugins/include/rmf_building_sim_gz_plugins/components/Door.hpp
+++ b/rmf_building_sim_gz_plugins/include/rmf_building_sim_gz_plugins/components/Door.hpp
@@ -55,10 +55,6 @@ GZ_SIM_REGISTER_COMPONENT("rmf_components.Door", Door)
 /// \brief A component used to command an RMF door to open / close.
 using DoorCmd = Component<DoorModeCmp, class DoorCmdTag>;
 GZ_SIM_REGISTER_COMPONENT("rmf_components.DoorCmd", DoorCmd)
-
-/// \brief A component used to show the state of an RMF door.
-using DoorStateComp = Component<DoorModeCmp, class DoorStateTag>;
-GZ_SIM_REGISTER_COMPONENT("rmf_components.DoorStateComp", DoorStateComp)
 }
 }
 }

--- a/rmf_building_sim_gz_plugins/src/door.cpp
+++ b/rmf_building_sim_gz_plugins/src/door.cpp
@@ -112,7 +112,7 @@ private:
   {
     double dx = target - current_position;
     if (std::abs(dx) < params.dx_min / 2.0)
-      return 0.0;
+      dx = 0.0;
 
     double door_v = compute_desired_rate_of_change(
       dx, current_velocity, params, dt);
@@ -231,7 +231,7 @@ public:
           components::JointPosition(position));
         }
         enableComponent<components::DoorStateComp>(ecm, entity);
-        ecm->CreateComponent<components::DoorCmd>(entity,
+        ecm.CreateComponent<components::DoorCmd>(entity,
         components::DoorCmd(DoorModeCmp::CLOSE));
         return true;
       });
@@ -283,13 +283,14 @@ public:
         const auto cur_mode = get_current_mode(entity, ecm, door);
         if (door_comp->Data().ros_interface)
         {
-          auto it = _last_state_pub.find(e);
+          auto it = _last_state_pub.find(entity);
           if (it != _last_state_pub.end() && t - it->second >= PUBLISH_DT)
           {
             it->second = t;
             publish_state(t, name, cur_mode);
           }
         }
+        door_state_comp->Data() = cur_mode;
         return true;
       });
   }

--- a/rmf_building_sim_gz_plugins/src/door.cpp
+++ b/rmf_building_sim_gz_plugins/src/door.cpp
@@ -230,7 +230,6 @@ public:
           ecm.CreateComponent<components::JointPosition>(joint_entity,
           components::JointPosition(position));
         }
-        enableComponent<components::DoorStateComp>(ecm, entity);
         ecm->CreateComponent<components::DoorCmd>(entity,
         components::DoorCmd(DoorModeCmp::CLOSE));
         return true;
@@ -268,10 +267,9 @@ public:
     const double t = to_seconds(info.simTime);
     // Process commands
     ecm.Each<components::Door, components::DoorCmd,
-      components::DoorStateComp, components::Name>([&](const Entity& entity,
+      components::Name>([&](const Entity& entity,
       const components::Door* door_comp,
       const components::DoorCmd* door_cmd_comp,
-      components::DoorStateComp* door_state_comp,
       const components::Name* name_comp) -> bool
       {
         double dt = to_seconds(info.dt);

--- a/rmf_building_sim_gz_plugins/src/door.cpp
+++ b/rmf_building_sim_gz_plugins/src/door.cpp
@@ -230,6 +230,7 @@ public:
           ecm.CreateComponent<components::JointPosition>(joint_entity,
           components::JointPosition(position));
         }
+        enableComponent<components::DoorStateComp>(ecm, entity);
         ecm->CreateComponent<components::DoorCmd>(entity,
         components::DoorCmd(DoorModeCmp::CLOSE));
         return true;
@@ -267,9 +268,10 @@ public:
     const double t = to_seconds(info.simTime);
     // Process commands
     ecm.Each<components::Door, components::DoorCmd,
-      components::Name>([&](const Entity& entity,
+      components::DoorStateComp, components::Name>([&](const Entity& entity,
       const components::Door* door_comp,
       const components::DoorCmd* door_cmd_comp,
+      components::DoorStateComp* door_state_comp,
       const components::Name* name_comp) -> bool
       {
         double dt = to_seconds(info.dt);

--- a/rmf_building_sim_gz_plugins/src/door.cpp
+++ b/rmf_building_sim_gz_plugins/src/door.cpp
@@ -112,7 +112,7 @@ private:
   {
     double dx = target - current_position;
     if (std::abs(dx) < params.dx_min / 2.0)
-      dx = 0.0;
+      return 0.0;
 
     double door_v = compute_desired_rate_of_change(
       dx, current_velocity, params, dt);
@@ -231,6 +231,8 @@ public:
           components::JointPosition(position));
         }
         enableComponent<components::DoorStateComp>(ecm, entity);
+        ecm->CreateComponent<components::DoorCmd>(entity,
+        components::DoorCmd(DoorModeCmp::CLOSE));
         return true;
       });
   }
@@ -264,7 +266,6 @@ public:
       return;
 
     const double t = to_seconds(info.simTime);
-    std::unordered_set<Entity> finished_cmds;
     // Process commands
     ecm.Each<components::Door, components::DoorCmd,
       components::DoorStateComp, components::Name>([&](const Entity& entity,
@@ -277,47 +278,20 @@ public:
         const auto& name = name_comp->Data();
         const auto& door = door_comp->Data();
         const auto& door_cmd = door_cmd_comp->Data();
-        auto& last_mode = door_state_comp->Data();
         command_door(entity, ecm, door, dt, door_cmd);
-        // Publish state if there was a change
+        // Publish state if we are past the deadline
         const auto cur_mode = get_current_mode(entity, ecm, door);
-        if (cur_mode != door_state_comp->Data())
+        if (door_comp->Data().ros_interface)
         {
-          last_mode = cur_mode;
-          if (door_comp->Data().ros_interface)
+          auto it = _last_state_pub.find(e);
+          if (it != _last_state_pub.end() && t - it->second >= PUBLISH_DT)
           {
+            it->second = t;
             publish_state(t, name, cur_mode);
           }
         }
-        if (door_cmd == cur_mode)
-        {
-          finished_cmds.insert(entity);
-        }
         return true;
       });
-
-    // Publish states
-    ecm.Each<components::Door, components::DoorStateComp,
-      components::Name>([&](const Entity& e,
-      const components::Door* door_comp,
-      const components::DoorStateComp* door_state_comp,
-      const components::Name* name_comp) -> bool
-      {
-        if (door_comp->Data().ros_interface == false)
-          return true;
-        auto it = _last_state_pub.find(e);
-        if (it != _last_state_pub.end() && t - it->second >= PUBLISH_DT)
-        {
-          it->second = t;
-          publish_state(t, name_comp->Data(), door_state_comp->Data());
-        }
-        return true;
-      });
-
-    for (const auto& entity: finished_cmds)
-    {
-      enableComponent<components::DoorCmd>(ecm, entity, false);
-    }
   }
 };
 


### PR DESCRIPTION
## Bug fix

### Fixed bug

Since as a form of optimization we stopped sending door commands when door were at the target state, small drift could cause them to slowly move to a different position.

### Fix applied

Always send the last door command to each door