### PR TITLE
Remove undefined behavior from the startup conditions

### DIFF
--- a/rmf_building_sim_gz_plugins/src/lift.cpp
+++ b/rmf_building_sim_gz_plugins/src/lift.cpp
@@ -457,7 +457,8 @@ public:
             cur_lift_cmd.request_type != msg->request_type ||
             cur_lift_cmd.session_id != msg->session_id)
             {
-              gzwarn << "Discarding request to go to [" << msg->destination_floor
+              gzwarn << "Discarding request to go to ["
+                << msg->destination_floor
                 << "] for [" << msg->session_id << "]. Lift ["
                 << msg->lift_name << "] is busy going to ["
                 << cur_lift_cmd.destination_floor << "] for ["

--- a/rmf_building_sim_gz_plugins/src/lift.cpp
+++ b/rmf_building_sim_gz_plugins/src/lift.cpp
@@ -458,11 +458,11 @@ public:
             cur_lift_cmd.session_id != msg->session_id)
             {
               gzwarn << "Discarding request to go to ["
-                << msg->destination_floor
-                << "] for [" << msg->session_id << "]. Lift ["
-                << msg->lift_name << "] is busy going to ["
-                << cur_lift_cmd.destination_floor << "] for ["
-                << cur_lift_cmd.session_id << "]" << std::endl;
+                     << msg->destination_floor
+                     << "] for [" << msg->session_id << "]. Lift ["
+                     << msg->lift_name << "] is busy going to ["
+                     << cur_lift_cmd.destination_floor << "] for ["
+                     << cur_lift_cmd.session_id << "]" << std::endl;
               return;
             }
           }

--- a/rmf_building_sim_gz_plugins/src/lift.cpp
+++ b/rmf_building_sim_gz_plugins/src/lift.cpp
@@ -145,6 +145,7 @@ private:
           }
         }
         lift_command.destination_floor = initial_floor;
+        lift_command.door_state = DoorModeCmp::CLOSE;
         _last_lift_command[entity] = lift_command;
 
         std::vector<double> joint_position = {target_elevation};
@@ -338,6 +339,7 @@ private:
       {
         continue;
       }
+
       if (door_state_comp->Data() != cmd)
         return false;
     }
@@ -455,8 +457,11 @@ public:
             cur_lift_cmd.request_type != msg->request_type ||
             cur_lift_cmd.session_id != msg->session_id)
             {
-              gzwarn << "Discarding request: [" << msg->lift_name <<
-                "] is busy at the moment" << std::endl;
+              gzwarn << "Discarding request to go to [" << msg->destination_floor
+                << "] for [" << msg->session_id << "]. Lift ["
+                << msg->lift_name << "] is busy going to ["
+                << cur_lift_cmd.destination_floor << "] for ["
+                << cur_lift_cmd.session_id << "]" << std::endl;
               return;
             }
           }


### PR DESCRIPTION
I noticed a very non-deterministic behavior where sometimes one or more lifts would be unable to function from the moment the simulation started, and nothing seemed to allow them to recover. This would only happen once in a while and there was no consistency except that it happened immediately at startup and not under any other circumstance.

After some debugging I found that the `DoorModeCmp` for lifts was being initialized without a specific value set for the `door_state`. Most of the time memory used by programs will be zero-initialized, so most of the time the `door_state` field was getting set to 0, which coincidentally gives us the correct behavior. But a zero-initialization is not guaranteed, so when that doesn't happen the `door_state` field will be some arbitrary number, and then the state machine for the lift will just never be functional.

This PR simply makes sure that field is set to the correct value at initialization. I haven't seen the bug happen again after this fix.