### PR TITLE
Add environment hooks for plugins path

### DIFF
--- a/rmf_building_sim_gz_plugins/CMakeLists.txt
+++ b/rmf_building_sim_gz_plugins/CMakeLists.txt
@@ -46,6 +46,8 @@ find_package(Qt5
 )
 find_package(menge_vendor REQUIRED)
 
+ament_environment_hooks("${CMAKE_CURRENT_SOURCE_DIR}/hooks/${PROJECT_NAME}.dsv.in")
+
 include(GNUInstallDirs)
 
 ###############################

--- a/rmf_building_sim_gz_plugins/hooks/rmf_building_sim_gz_plugins.dsv.in
+++ b/rmf_building_sim_gz_plugins/hooks/rmf_building_sim_gz_plugins.dsv.in
@@ -1,0 +1,2 @@
+prepend-non-duplicate;GZ_SIM_SYSTEM_PLUGIN_PATH;lib/rmf_building_sim_gz_plugins/
+prepend-non-duplicate;GZ_GUI_PLUGIN_PATH;lib/rmf_building_sim_gz_plugins/

--- a/rmf_robot_sim_gz_plugins/CMakeLists.txt
+++ b/rmf_robot_sim_gz_plugins/CMakeLists.txt
@@ -48,6 +48,8 @@ find_package (Qt5
   REQUIRED
 )
 
+ament_environment_hooks("${CMAKE_CURRENT_SOURCE_DIR}/hooks/${PROJECT_NAME}.dsv.in")
+
 include(GNUInstallDirs)
 
 ###############################

--- a/rmf_robot_sim_gz_plugins/hooks/rmf_robot_sim_gz_plugins.dsv.in
+++ b/rmf_robot_sim_gz_plugins/hooks/rmf_robot_sim_gz_plugins.dsv.in
@@ -1,0 +1,2 @@
+prepend-non-duplicate;GZ_SIM_SYSTEM_PLUGIN_PATH;lib/rmf_robot_sim_gz_plugins/
+prepend-non-duplicate;GZ_GUI_PLUGIN_PATH;lib/rmf_robot_sim_gz_plugins/


### PR DESCRIPTION
## New feature implementation

### Implementation description

Add environment hooks to set the right environment variables when sourcing the workspace. This means that as soon as this package is built and sourced the plugins will be found automatically without users having to manually set their environments.