### PR TITLE
Add environment hooks for plugins path (#136)

### DIFF
--- a/rmf_building_sim_gz_plugins/CMakeLists.txt
+++ b/rmf_building_sim_gz_plugins/CMakeLists.txt
@@ -46,6 +46,8 @@ find_package(Qt5
 )
 find_package(menge_vendor REQUIRED)
 
+ament_environment_hooks("${CMAKE_CURRENT_SOURCE_DIR}/hooks/${PROJECT_NAME}.dsv.in")
+
 include(GNUInstallDirs)
 
 ###############################

--- a/rmf_building_sim_gz_plugins/hooks/rmf_building_sim_gz_plugins.dsv.in
+++ b/rmf_building_sim_gz_plugins/hooks/rmf_building_sim_gz_plugins.dsv.in
@@ -1,0 +1,2 @@
+prepend-non-duplicate;GZ_SIM_SYSTEM_PLUGIN_PATH;lib/rmf_building_sim_gz_plugins/
+prepend-non-duplicate;GZ_GUI_PLUGIN_PATH;lib/rmf_building_sim_gz_plugins/

--- a/rmf_robot_sim_gz_plugins/CMakeLists.txt
+++ b/rmf_robot_sim_gz_plugins/CMakeLists.txt
@@ -48,6 +48,8 @@ find_package (Qt5
   REQUIRED
 )
 
+ament_environment_hooks("${CMAKE_CURRENT_SOURCE_DIR}/hooks/${PROJECT_NAME}.dsv.in")
+
 include(GNUInstallDirs)
 
 ###############################

--- a/rmf_robot_sim_gz_plugins/hooks/rmf_robot_sim_gz_plugins.dsv.in
+++ b/rmf_robot_sim_gz_plugins/hooks/rmf_robot_sim_gz_plugins.dsv.in
@@ -1,0 +1,2 @@
+prepend-non-duplicate;GZ_SIM_SYSTEM_PLUGIN_PATH;lib/rmf_robot_sim_gz_plugins/
+prepend-non-duplicate;GZ_GUI_PLUGIN_PATH;lib/rmf_robot_sim_gz_plugins/


### PR DESCRIPTION
Backport environment hooks to `jazzy`, as discussed in https://github.com/open-rmf/rmf_demos/pull/303.