### PR TITLE
Use a world plugin for chargers registration

### DIFF
--- a/rmf_building_sim_gz_plugins/include/rmf_building_sim_gz_plugins/components/Charger.hpp
+++ b/rmf_building_sim_gz_plugins/include/rmf_building_sim_gz_plugins/components/Charger.hpp
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2025 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+#ifndef RMF_BUILDING_SIM_GZ_PLUGINS_COMPONENTS_CHARGER_HPP
+#define RMF_BUILDING_SIM_GZ_PLUGINS_COMPONENTS_CHARGER_HPP
+
+#include <gz/sim/components/Factory.hh>
+#include <gz/sim/components/Component.hh>
+#include <gz/sim/config.hh>
+
+namespace gz {
+namespace sim {
+// Marker component for chargers, data such as name and pose is contained
+// in builtin Name and Pose gz components
+struct ChargerData {};
+
+namespace components {
+/// \brief A component used to describe an RMF robot charger.
+using Charger = Component<ChargerData, class DoorTag>;
+GZ_SIM_REGISTER_COMPONENT("rmf_components.Charger", Charger)
+}
+}
+}
+#endif
+

--- a/rmf_building_sim_gz_plugins/src/register_component.cpp
+++ b/rmf_building_sim_gz_plugins/src/register_component.cpp
@@ -39,6 +39,7 @@ private:
       {
         gzerr << "Failed initializing charger plugin, reason: [" << *err << "]" << std::endl;
       }
+      component_element = component_element->GetNextElement("rmf_charger");
     }
   }
 

--- a/rmf_robot_sim_gz_plugins/src/slotcar.cpp
+++ b/rmf_robot_sim_gz_plugins/src/slotcar.cpp
@@ -62,7 +62,7 @@ private:
   Eigen::Isometry3d _pose;
   std::unordered_set<Entity> _obstacle_exclusions;
   std::unordered_map<Entity, Eigen::Vector3d> _dispensable_positions;
-  std::vector<Eigen::Vector3d> _charger_positions;
+  bool _initialized_charger_positions = false;
   double _height = 0;
 
   bool _read_aabb_dimensions = true;
@@ -306,7 +306,7 @@ const std::vector<Eigen::Vector3d> SlotcarPlugin::get_charger_positions(
     const components::Pose* pose
     ) -> bool
     {
-      _charger_positions.push_back(rmf_plugins_utils::convert_vec(pose->Data().Pos()));
+      charger_positions.push_back(rmf_plugins_utils::convert_vec(pose->Data().Pos()));
       return true;
     });
   return charger_positions;
@@ -520,10 +520,11 @@ void SlotcarPlugin::PreUpdate(const UpdateInfo& info,
     init_obstacle_exclusions(ecm);
   }
 
-  if (_charger_positions.empty())
+  if (!_initialized_charger_positions)
   {
     auto chargers = get_charger_positions(ecm);
     dataPtr->set_charger_positions(chargers);
+    _initialized_charger_positions = true;
   }
 
   // Don't update the pose if the simulation is paused

--- a/rmf_robot_sim_gz_plugins/src/slotcar.cpp
+++ b/rmf_robot_sim_gz_plugins/src/slotcar.cpp
@@ -24,6 +24,7 @@
 #include <rmf_robot_sim_common/utils.hpp>
 #include <rmf_robot_sim_common/slotcar_common.hpp>
 
+#include <rmf_building_sim_gz_plugins/components/Charger.hpp>
 #include <rmf_building_sim_gz_plugins/components/Door.hpp>
 #include <rmf_building_sim_gz_plugins/components/Lift.hpp>
 
@@ -61,6 +62,7 @@ private:
   Eigen::Isometry3d _pose;
   std::unordered_set<Entity> _obstacle_exclusions;
   std::unordered_map<Entity, Eigen::Vector3d> _dispensable_positions;
+  std::vector<Eigen::Vector3d> _charger_positions;
   double _height = 0;
 
   bool _read_aabb_dimensions = true;
@@ -78,6 +80,8 @@ private:
     const double target_linear_speed_destination,
     const std::optional<double>& max_linear_velocity);
   void init_obstacle_exclusions(EntityComponentManager& ecm);
+  const std::vector<Eigen::Vector3d> get_charger_positions(
+    EntityComponentManager& ecm);
   bool get_slotcar_height(const gz::msgs::Entity& req,
     gz::msgs::Double& rep);
   std::pair<std::vector<Eigen::Vector3d>, std::unordered_map<Entity,
@@ -291,6 +295,23 @@ void SlotcarPlugin::init_obstacle_exclusions(EntityComponentManager& ecm)
   _obstacle_exclusions.insert(_entity);
 }
 
+const std::vector<Eigen::Vector3d> SlotcarPlugin::get_charger_positions(
+  EntityComponentManager& ecm)
+{
+  std::vector<Eigen::Vector3d> charger_positions;
+  // Cycle through all the entities with the Charger component
+  ecm.Each<components::Charger, components::Pose>(
+    [&](const Entity&,
+    const components::Charger*,
+    const components::Pose* pose
+    ) -> bool
+    {
+      _charger_positions.push_back(rmf_plugins_utils::convert_vec(pose->Data().Pos()));
+      return true;
+    });
+  return charger_positions;
+}
+
 std::pair<std::vector<Eigen::Vector3d>, std::unordered_map<Entity,
   Eigen::Vector3d>>
 SlotcarPlugin::get_obstacle_positions(EntityComponentManager& ecm)
@@ -495,7 +516,15 @@ void SlotcarPlugin::PreUpdate(const UpdateInfo& info,
   // After initialization once, this set will have at least one exclusion, which
   // is the itself.
   if (_obstacle_exclusions.empty())
+  {
     init_obstacle_exclusions(ecm);
+  }
+
+  if (_charger_positions.empty())
+  {
+    auto chargers = get_charger_positions(ecm);
+    dataPtr->set_charger_positions(chargers);
+  }
 
   // Don't update the pose if the simulation is paused
   if (info.paused)


### PR DESCRIPTION
## Bug fix

### Fixed bug

Fixes #142, requires https://github.com/open-rmf/rmf_traffic_editor/pull/532

### Fix applied

As described in the issue, I took the approach of introducing a world plugin that registers all the chargers. Previously chargers used to have a pair of `x,y` coordinates, a name and a level name. I wrapped all that data in a single structure before realizing that if we switch from using `level_name` to using `z` we can just reuse the `Pose` component.

The current logic then, is that for each charger in the world a new entity will be spawned and it will have:

* A `gz::components::Name` with its name
* A `gz::components::Pose` with its pose
* A new `Charger` component (currently an empty struct) that marks it as a charger.

In the future we can extend the marker struct with charger specific data, as well as use the same logic to register single chargers, rather than relying on a world plugin for them