### PR TITLE
Fix slotcar final orientation

### DIFF
--- a/rmf_robot_sim_common/src/slotcar_common.cpp
+++ b/rmf_robot_sim_common/src/slotcar_common.cpp
@@ -876,7 +876,7 @@ double SlotcarCommon::compute_change_in_rotation(
   const Eigen::Vector3d* requested_heading,
   double* const dir) const
 {
-  if (dpos.norm() < 1e-3)
+  if (dpos.norm() < 1e-3 && !requested_heading)
   {
     // We're right next to the waypoint, so we don't really need any heading
     // to reach it.


### PR DESCRIPTION
## Bug fix

### Fixed bug
Robots do not rotate to the requested final orientation.

### Fix applied
**a. Root cause:**
When a caller ([specifically when processing final destination orientation](https://github.com/open-rmf/rmf_simulation/blob/9c9462a942552dddcbe07f341ca4da3383bdf0dd/rmf_robot_sim_common/src/slotcar_common.cpp#L592-L601)) passes `dpos = Zero()` along with a `requested_heading`, the early-return `if (dpos.norm() < 1e-3)` always triggers first and returns 0.0. The `requested_heading` is never processed, so the function reports rotation change  = 0.0.

**b. Fix:**
Added a `&& !requested_heading` check so the early-return doesn't trigger when the caller actually requests a rotation.

**c. To Test:**
1. launch office
```
ros2 launch rmf_demos_gz office.launch.xml
```
2. send robot to a `patrol_A2` with specific orientation 90 degree
```
ros2 run rmf_demos_tasks dispatch_go_to_place -p patrol_A2 -o 90 --use_sim_time
```


