### PR TITLE
Fix deprecation warning and error on rolling

### DIFF
--- a/rmf_robot_sim_common/include/rmf_robot_sim_common/slotcar_common.hpp
+++ b/rmf_robot_sim_common/include/rmf_robot_sim_common/slotcar_common.hpp
@@ -22,7 +22,7 @@
 
 #include <rclcpp/rclcpp.hpp>
 #include <Eigen/Geometry>
-#include <tf2_ros/transform_broadcaster.h>
+#include <tf2_ros/transform_broadcaster.hpp>
 
 #include <geometry_msgs/msg/transform_stamped.hpp>
 #include <rmf_fleet_msgs/msg/robot_collision.hpp>

--- a/rmf_robot_sim_common/src/slotcar_common.cpp
+++ b/rmf_robot_sim_common/src/slotcar_common.cpp
@@ -205,7 +205,8 @@ void SlotcarCommon::init_ros_node(const rclcpp::Node::SharedPtr node)
   _current_mode.mode = RobotMode::MODE_MOVING;
   _ros_node = std::move(node);
 
-  _tf2_broadcaster = std::make_shared<tf2_ros::TransformBroadcaster>(_ros_node);
+  _tf2_broadcaster =
+    std::make_shared<tf2_ros::TransformBroadcaster>(*_ros_node);
 
   _robot_state_pub =
     _ros_node->create_publisher<rmf_fleet_msgs::msg::RobotState>(


### PR DESCRIPTION
## Bug fix

### Fixed bug

Builds have been failing in Rolling because of a deprecated API in tf2_ros that was removed, there is also a deprecated header we are using that we should address.
Failing CI: https://github.com/open-rmf/rmf_simulation/actions/runs/29714583474/job/88265118756

### Fix applied

Fix both

### GenAI Use
We follow [OSRA's policy on GenAI tools](https://github.com/openrobotics/osrf-policies-and-procedures/blob/main/OSRF%20Policy%20on%20the%20Use%20of%20Generative%20Tools%20(%E2%80%9CGenerative%20AI%E2%80%9D)%20in%20Contributions.md)

- [ ] I used a GenAI tool in this PR.
- [x] I did not use GenAI