### PR TITLE
Fix uninitialized door_state in self-generated LiftCommand causing permanent lift command latch

### DIFF
--- a/rmf_building_sim_gz_plugins/src/lift.cpp
+++ b/rmf_building_sim_gz_plugins/src/lift.cpp
@@ -114,6 +114,7 @@ private:
 
         LiftCommand lift_command;
         lift_command.request_type = LiftRequest::REQUEST_AGV_MODE;
+        lift_command.door_state = DoorModeCmp::CLOSE;
         // Set the initial floor
         const auto target_it = lift.floors.find(lift.initial_floor);
         auto initial_floor = std::string("");


### PR DESCRIPTION
## Summary

`LiftPlugin::initialize_components()` builds the startup `LiftCommand` without
assigning `door_state`, leaving it as indeterminate stack memory. If the value
isn't `DoorModeCmp::CLOSE`, the command can never satisfy its completion
condition, so `components::LiftCmd` latches permanently and every subsequent
`/lift_requests` message is discarded as "busy". Since the value is
uninitialized, it reproduces intermittently across restarts.

## Fix

Initialize `door_state` to `CLOSE`, matching the doors' physical state at
startup. The discard logic itself is unchanged.

## Verification

`colcon build --packages-select rmf_building_sim_gz_plugins` succeeds.
Not verified in an actual simulation run — the value is stack garbage, so a
single run wouldn't be conclusive either way.
